### PR TITLE
Apollo ssr

### DIFF
--- a/docs/Offline-ApolloOffline.md
+++ b/docs/Offline-ApolloOffline.md
@@ -88,7 +88,8 @@ const client = new ApolloClient({
 });
 
 
-// await before instantiating Query, else queries might run before the cache is persisted, TODO ApolloProviderOffline
+// await before instantiating Query, else queries might run before the cache is persisted
+// or use apollo-offline useQuery
 await client.hydrated(): Promise<boolean>
 
 ```
@@ -186,7 +187,27 @@ const cacheOptions = {
     dataIdFromObject: o => o.id
   }
 
-const client = ApolloClientIDB.create({ link: httpLink }, cacheOptions);
+const client = ApolloClientIDB.create({ link: httpLink }, { 
+  cacheOptions
+});
+```
+
+**ApolloClientIDB.create function**
+
+```ts
+public static create(
+  config: ApolloClientIDBOptions,
+  options: {
+    cacheOptions?: InMemoryCacheConfig;
+    persistOptions?: CacheOptions;
+    offlineStoreOptions?: CacheOptions;
+    idbOptions?: {
+      name?: string;
+      onUpgrade?: IOnUpgrade;
+      version?: number;
+    };
+  },
+): ApolloClientOffline
 ```
 
 ## ApolloClient with PersistOfflineOptions
@@ -219,3 +240,16 @@ const client = new ApolloClient({
 [CacheOptions](Caching-CachePersist.md#cache-options)
 
 
+## useQuery
+
+the useQuery provides native management of client hydration.
+
+If the client is not hydrated, the hydration request is made and the application will have the same behavior as when it is offline and will be rendered with only the information present in the store if present.
+
+When the hydration promise is resolved, the useQuery is re-rendered.
+
+```ts
+
+import useQuery from '@wora/apollo-offline/lib/react/useQuery';
+
+```

--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/apollo-cache",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "keywords": [
     "cache",
     "wora",

--- a/packages/apollo-offline/package.json
+++ b/packages/apollo-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/apollo-offline",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "keywords": [
     "wora",
     "cache-persist",

--- a/packages/apollo-offline/package.json
+++ b/packages/apollo-offline/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "apollo-client": "^2.6.0",
-    "graphql": "14.4.2"
+    "graphql": "14.4.2",
+    "@apollo/react-hooks": "3.1.3"
   }
 }

--- a/packages/apollo-offline/src/ApolloClientIDB.ts
+++ b/packages/apollo-offline/src/ApolloClientIDB.ts
@@ -5,37 +5,46 @@ import { InMemoryCacheConfig } from 'apollo-cache-inmemory';
 import ApolloCache from '@wora/apollo-cache';
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type ApolloClientIDBOptions = Omit<OfflineApolloClientOptions, 'cache'>; // Equivalent to: {b: number, c: boolean}
+type ApolloClientIDBOptions = Omit<OfflineApolloClientOptions, 'cache'>;
 
 class ApolloClientIDB {
     public static create(
         config: ApolloClientIDBOptions,
-        cacheOptions: InMemoryCacheConfig = {},
-        persistOptions: CacheOptions = {},
-        idbOptions: { onUpgrade?: IOnUpgrade; version?: number } = {},
+        options: {
+            cacheOptions?: InMemoryCacheConfig;
+            persistOptions?: CacheOptions;
+            offlineStoreOptions?: CacheOptions;
+            idbOptions?: {
+                name?: string;
+                onUpgrade?: IOnUpgrade;
+                version?: number;
+            };
+        } = {},
     ): ApolloClientOffline {
+        const { cacheOptions, persistOptions = {}, offlineStoreOptions = {}, idbOptions = {} } = options;
         let idbStore: CacheOptions;
         let idbOffline: CacheOptions;
-        const serialize: boolean = persistOptions.serialize;
-        const prefix: string = persistOptions.prefix;
         if (typeof window !== 'undefined') {
+            const { name = 'apollo', onUpgrade, version } = idbOptions;
             const idbStorages: Array<ICacheStorage> = IDBStorage.create({
-                name: prefix || 'apollo',
+                name,
                 storeNames: ['store', 'offline'],
-                onUpgrade: idbOptions.onUpgrade,
-                version: idbOptions.version,
+                onUpgrade,
+                version,
             });
 
             idbStore = {
                 storage: idbStorages[0],
-                serialize: serialize || false,
+                serialize: false,
                 prefix: null,
+                ...persistOptions,
             };
 
             idbOffline = {
                 storage: idbStorages[1],
-                serialize: serialize || false,
+                serialize: false,
                 prefix: null,
+                ...offlineStoreOptions,
             };
         }
 

--- a/packages/apollo-offline/src/ApolloClientIDB.ts
+++ b/packages/apollo-offline/src/ApolloClientIDB.ts
@@ -22,8 +22,16 @@ class ApolloClientIDB {
         } = {},
     ): ApolloClientOffline {
         const { cacheOptions, persistOptions = {}, offlineStoreOptions = {}, idbOptions = {} } = options;
-        let idbStore: CacheOptions;
-        let idbOffline: CacheOptions;
+        const idbStore: CacheOptions = {
+            serialize: false,
+            prefix: null,
+            ...persistOptions,
+        };
+        const idbOffline: CacheOptions = {
+            serialize: false,
+            prefix: null,
+            ...offlineStoreOptions,
+        };
         if (typeof window !== 'undefined') {
             const { name = 'apollo', onUpgrade, version } = idbOptions;
             const idbStorages: Array<ICacheStorage> = IDBStorage.create({
@@ -33,19 +41,8 @@ class ApolloClientIDB {
                 version,
             });
 
-            idbStore = {
-                storage: idbStorages[0],
-                serialize: false,
-                prefix: null,
-                ...persistOptions,
-            };
-
-            idbOffline = {
-                storage: idbStorages[1],
-                serialize: false,
-                prefix: null,
-                ...offlineStoreOptions,
-            };
+            idbStore.storage = idbStorages[0];
+            idbOffline.storage = idbStorages[1];
         }
 
         const cache = new ApolloCache(cacheOptions, idbStore);

--- a/packages/apollo-offline/src/ApolloClientOffline.ts
+++ b/packages/apollo-offline/src/ApolloClientOffline.ts
@@ -44,6 +44,8 @@ class OfflineApolloClient extends ApolloClient<NormalizedCacheObject> {
         if (!this.promisesRestore) {
             this.promisesRestore = Promise.all([this.getStoreOffline().hydrate(), (this.cache as ApolloStore).hydrate()])
                 .then((_result) => {
+                    (this.cache as any).broadcastWatches();
+                    this.queryManager.broadcastQueries();
                     this.rehydrated = true;
                     return true;
                 })

--- a/packages/apollo-offline/src/react/useQuery.tsx
+++ b/packages/apollo-offline/src/react/useQuery.tsx
@@ -1,0 +1,34 @@
+import { useState, useRef } from 'react';
+import { DocumentNode } from 'graphql';
+import { OperationVariables, QueryResult } from '@apollo/react-common';
+import { useQuery as useQueryApollo, useApolloClient, QueryHookOptions } from '@apollo/react-hooks';
+
+const useQuery = function<TData = any, TVariables = OperationVariables>(
+    query: DocumentNode,
+    options?: QueryHookOptions<TData, TVariables>,
+): QueryResult<TData, TVariables> {
+    const client: any = useApolloClient();
+    const [, forceUpdate] = useState(null);
+    const ref = useRef<{ hydrate: boolean; data: any }>({
+        hydrate: client.isRehydrated(),
+        data: null,
+    });
+
+    if (!ref.current.hydrate) {
+        ref.current.hydrate = true;
+        client.hydrate().then(() => {
+            const { data } = ref.current;
+            if (!data) forceUpdate(client);
+        });
+    }
+
+    const { data, ...others } = useQueryApollo(query, options);
+    ref.current.data = data;
+
+    return {
+        ...others,
+        data,
+    };
+};
+
+export default useQuery;

--- a/packages/cache-persist/package.json
+++ b/packages/cache-persist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/cache-persist",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "keywords": [
     "cache",
     "react-native",

--- a/packages/cache-persist/src/StorageProxy.ts
+++ b/packages/cache-persist/src/StorageProxy.ts
@@ -17,7 +17,7 @@ const SPLIT = '####';
 const NoStorageProxy: IStorageHelper = {
     restore: () => {
         return promiseResult(() => {
-            return {};
+            return undefined;
         });
     },
     push: (_keys: string) => undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@apollo/react-common@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
+  integrity sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==
+  dependencies:
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hooks@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
+  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@wry/equality" "^0.1.9"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -1980,12 +1998,12 @@
     semver "^6.2.0"
 
 "@wora/apollo-cache@file:packages/apollo-cache":
-  version "1.0.0"
+  version "2.0.2"
   dependencies:
-    "@wora/cache-persist" "file:../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v4/npm-@wora-apollo-cache-1.0.0-a7c3f4bc-0318-4d3c-9976-8530ba0f7cca-1572197361950/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../Library/Caches/Yarn/v4/npm-@wora-apollo-cache-2.0.2-5c21ad21-7762-4d11-9c64-5435a17c13bd-1573064255066/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
-  version "2.0.1"
+  version "2.0.3"
   dependencies:
     idb "^4.0.0"
 
@@ -1996,15 +2014,16 @@
     fbjs "^1.0.0"
 
 "@wora/offline-first@file:packages/offline-first":
-  version "1.1.0"
+  version "2.0.2"
   dependencies:
-    "@wora/cache-persist" "file:../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v4/npm-@wora-offline-first-1.1.0-90873af9-0ab2-4ea1-8c67-2058439bf6ea-1572197361948/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v4/npm-@wora-offline-first-1.1.0-90873af9-0ab2-4ea1-8c67-2058439bf6ea-1572197361948/node_modules/@wora/netinfo"
+    "@wora/cache-persist" "file:../../../../Library/Caches/Yarn/v4/npm-@wora-offline-first-2.0.2-db362a11-0d2e-463c-a330-41ccf99ce0e4-1573064255064/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../Library/Caches/Yarn/v4/npm-@wora-offline-first-2.0.2-db362a11-0d2e-463c-a330-41ccf99ce0e4-1573064255064/node_modules/@wora/netinfo"
+    fbjs "^1.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
-  version "1.0.0"
+  version "2.0.2"
   dependencies:
-    "@wora/cache-persist" "file:../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v4/npm-@wora-relay-store-1.0.0-0821c584-d306-4707-9a31-abdccef25c00-1572197361951/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../Library/Caches/Yarn/v4/npm-@wora-relay-store-2.0.2-2ffb7472-7154-4000-8866-983636b71dd9-1573064255066/node_modules/@wora/cache-persist"
 
 "@wry/context@^0.4.0":
   version "0.4.4"
@@ -2014,7 +2033,7 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -9256,7 +9275,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-invariant@^0.4.0:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
@@ -9290,7 +9309,7 @@ tsconfig-paths@^3.6.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
* **ApolloClientIDB.create function** https://github.com/morrys/wora/issues/22

```ts
public static create(
  config: ApolloClientIDBOptions,
  options: {
    cacheOptions?: InMemoryCacheConfig;
    persistOptions?: CacheOptions;
    offlineStoreOptions?: CacheOptions;
    idbOptions?: {
      name?: string;
      onUpgrade?: IOnUpgrade;
      version?: number;
    };
  },
): ApolloClientOffline
```

* **added broadcastQueries when client is rehydrated**

* **added useQuery** https://github.com/morrys/wora/issues/23
the useQuery provides native management of client hydration.
If the client is not hydrated, the hydration request is made and the application will have the same behavior as when it is offline and will be rendered with only the information present in the store if present.
When the hydration promise is resolved, the useQuery is re-rendered.
```ts

import useQuery from '@wora/apollo-offline/lib/react/useQuery';

```