### PR TITLE
dispose function & allows offline mutations without optimistic response

### DIFF
--- a/packages/apollo-offline/package.json
+++ b/packages/apollo-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/apollo-offline",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "keywords": [
     "wora",
     "cache-persist",

--- a/packages/apollo-offline/src/ApolloClientOffline.ts
+++ b/packages/apollo-offline/src/ApolloClientOffline.ts
@@ -102,15 +102,7 @@ export class ApolloClientOffline extends ApolloClient<NormalizedCacheObject> {
     }
 
     public mutateOffline<T>(mutationOptions: MutationOptions): Promise<FetchResult<T>> {
-        const {
-            context,
-            optimisticResponse,
-            update,
-            fetchPolicy,
-            variables,
-            mutation,
-            updateQueries: updateQueriesByName,
-        } = mutationOptions;
+        const { context, update, fetchPolicy, variables, mutation, updateQueries: updateQueriesByName } = mutationOptions;
 
         const generateUpdateQueriesInfo: () => {
             [queryId: string]: QueryWithUpdater;
@@ -133,6 +125,11 @@ export class ApolloClientOffline extends ApolloClient<NormalizedCacheObject> {
 
             return ret;
         };
+
+        const optimisticResponse =
+            typeof mutationOptions.optimisticResponse === 'function'
+                ? mutationOptions.optimisticResponse(variables)
+                : mutationOptions.optimisticResponse;
 
         const result = { data: optimisticResponse };
         const id = uuid();

--- a/packages/offline-first/package.json
+++ b/packages/offline-first/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/offline-first",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "keywords": [
     "cache",
     "wora",

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-offline",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "keywords": [
     "wora",
     "cache-persist",

--- a/packages/relay-offline/src/Environment.ts
+++ b/packages/relay-offline/src/Environment.ts
@@ -88,6 +88,10 @@ export class Environment extends RelayEnvironment {
         });
     }
 
+    public dispose(): void {
+        this.getStoreOffline().dispose();
+    }
+
     public hydrate(): Promise<boolean> {
         if (!this.promisesRestore) {
             this.promisesRestore = Promise.all([this.getStoreOffline().hydrate(), ((this as any)._store as Store).hydrate()])


### PR DESCRIPTION
* [relay-offline, apollo-offline, offline-first] added dispose function, allows you to dispose the netinfo listener.
* [apollo-offline] allow offline execution of mutations that do not modify the store
 https://github.com/morrys/wora/issues/7