### PR TITLE
[relay-store] - support relay v10.x.x

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "trailingComma": "all",
   "arrowParens": "always",
   "printWidth": 140,
-  "parser": "typescript"
+  "parser": "typescript",
+  "endOfLine": "auto"
 }

--- a/docs/Caching-CachePersist.md
+++ b/docs/Caching-CachePersist.md
@@ -3,117 +3,91 @@ id: cache-persist
 title: Cache Persist
 ---
 
+As already mentioned, this library allows you, with very little effort of work, to manage the state within your application and its persistence in storage.
 
-## Architecture
+All you need to know to use it is the **Cache class** and the **configurations** it makes available to you.
 
-![alt-text](assets/cache-persist-architecture.png)
+So why wait, let’s start right now by viewing the wora/cache-persist Cache:
 
-### Cache
+As you can see from the interface above, there are 3 categories of functions:
 
-The cache is the component that manages the local cache of the application and is the only component with which the application must interface.
+  * **to read:** these functions, synchronous, allow you to read state data
+  * **to write:** these functions, synchronous, allow you to write data in the state
+  * **to manage persistence:** these functions allow you to manage the persistence of state within the storage
 
-**Allows the use of any storage in synchronous mode.** 
-The only asynchronous methods they expose are:
+**The read and write functions are very similar to those of the Map object, so I do not need to add anything** else while the **restore, isRehydrated and flush functions are described below** so that you better understand when and how to use them.
 
-`restore`, necessary to recover and initialize the state.
+  * **restore: it is the most important function of all**, in fact it must necessarily be used in order to connect the store to its reference storage and initialize the cache state. Apart from special situations, e.g. Server Side Rendering, this function is recommended to be called when starting the application.
+  * **flush:** this function allows you to make sure that the storage is synchronized with state data.
+  * **isRehydrated:** this function lets you know if the cache has been connected with the storage via the restore function
 
-`flush`, forces data to be stored in the persistence queue
+Well, now we can see how to use the cache within our application.
 
-```ts
-export interface ICache {
-    purge(): void;
-    replace(data: any): void;
-    isRehydrated(): boolean;
-    getState(): Readonly<{ [key: string]: any }>;
-    get(key: string): any;
-    set(key: string, value: any): void;
-    has(key: string): boolean;
-    delete(key: string): void;
-    remove(key: string): void;
-    getAllKeys(): Array<string>;
-    subscribe(callback: (state: any, action: any) => void): () => void;
-    notify(payload?: { state?: any; action?: any }): void;
-    getStorage(): ICacheStorage;
-    restore(): Promise<DataCache>;
-    flush(): Promise<void>;
-}
-```
+First, let’s install the packages we need:
 
-### Storage Proxy
-
-The proxy storage is the intermediary that connects the local cache to the storage.
-
-### Middleware Layer
-
-In the middleware level there are all the transformation and verification logics that are performed during the communication between the cache and the storage.
-
-The layers currently available within the library are:
-
-* **prefixLayer**: layer that handles the key prefix (<prefix>. <originalkey>), is inserted as the first layer when the **prefix option** is different from null 
-
-* **jsonSerialize**:  layer that handles JSON serialization and deserialization of values, is inserted as the last layer when the **serialize option** is true
-
-* **filterKeys**: this layer allows you to define a function to determine which keys persist.
-
-
-It is possible to implement any other layer component by implementing the interface described below:
-
-```ts
-export interface IMutateKey {
-    set(key: string): string | null;
-    get(key: string): string | null;
-}
-
-export interface IMutateValue {
-    set(value: any): any;
-    get(value: any): any;
-}
-```
-
-
-### Storage
-
-Inside the library there is the possibility to use the following storage: 
-
-**localStorage (web default)**
-
-**AsyncStorage (default react-native)**
-
-**sessionStorage**
-
-**IndexedDB**
-
-
-If you need to use different storage than those currently provided, simply create a customized storage that implements the following interface:
-
-```ts
-export interface ICacheStorage {
-    multiRemove?(keys: Array<string>): Promise<void>;
-    multiGet?(keys: Array<string>): Promise<Array<Array<string>>>;
-    multiSet?(items: Array<Array<string>>): Promise<void>;
-    getAllKeys(): Promise<Array<string>>;
-    getItem(key: string): Promise<string>;
-    setItem(key: string, value: string): Promise<void>;
-    removeItem(key: string): Promise<void>;
-}
-```
-
-
-## Installation
-
-Install @wora/cache-persist using yarn or npm:
+ * wora/cache-persist using yarn or npm:
 
 ```
 yarn add @wora/cache-persist
 ```
 
-## Cache Options
+Now, I can show you the simplest use case:
+
+```ts
+import { Cache } from "@wora/cache-persist";
+export const cache = new Cache();
+
+// ...
+await cache.restore();
+// ...
+
+cache.set('name', 'lorenzo');
+const name = cache.get('name');
+```
+
+That’s all :)
+
+Obviously only in very rare cases are we lucky enough to have to manage such a simple case where we use the localStorage (or for ReactNative the AsyncStorage) without one of these problems:
+
+  * How can I initialize the cache with data?
+  * There is data in the storage that is not compatible with the new version of the application, how can I migrate it?
+  * How can I use the same storage to manage different states? (e.g. different state based on the logged in user)
+  * How can I use indexedDB?
+  * How can I use session storage?
+  * How can I prevent some state data from being saved within the storage?
+  * How can I encrypt the data before it is saved in the storage?
+  * How do I handle storage errors when saving data?
+
+The library gives an answer to these problems (and not only these) through its configurations.
+
+For this reason I will start by describing all its configurations and then I will show you how to use them to answer the problems indicated above
+
+
+## Cache Options:
+
+`prefix:` [Optional][Default: cache] when this option is defined, the prefixLayer mutation included in the library is used in order to add / remove the prefix to persisted keys.
+
+`serialize:` [Optional][Default: true] when this option is true, the jsonSerialize mutation included in the library is used in order to handles JSON serialization and deserialization of values
+
+`mutateKeys:` [Optional] with this option you can configure an array of mutation functions that will be executed in order to change the keys while writing / reading in the storage. The prefix option will insert the prefixLayer function as the first in the list.
+
+`mutateValues:` [Optional] with this option you can configure an array of mutation functions that will be executed in order to change the values while writing / reading in the storage. The serialize option will insert the jsonSerialize function as the last in the list.
+
+`webStorage:` [Optional][Default: local] with this option it is possible to decide to use the sessionStorage by enhancing the property with session
+
+`storage:` [Optional][Default: localStorage/AsyncStorage] when you need to use custom storage or the indexedb, this property must be set.
+
+`throttle:` [Optional][Default: 500] Defines the expiration interval of the debounce
+
+`errorHandling:` [Optional] Allows you to define the callback function that is executed in case errors are raised during the write process to the storage.
+
+`disablePersist:` [Optional][Default: false] Allows you to use the cache as an inmemory cache.
 
 ```ts
 export type CacheOptions = {
+    initialState?: DataCache;
     serialize?: boolean;
     prefix?: string | undefined | null;
-    initialState?: DataCache;
     mergeState?: (restoredState?: DataCache, initialState?: DataCache) => Promise<DataCache> | DataCache;
     mutateKeys?: Array<IMutateKey>;
     mutateValues?: Array<IMutateValue>;
@@ -125,37 +99,69 @@ export type CacheOptions = {
 };
 ```
 
-* **storage:** custom storage, localStorage is used as the default react web persistence, while AsyncStorage is used for react-native.
- 
-* **mergeState:** callback called during the restore that allows to merge the data recovered from the store and the initial data.
+### How can I initialize the cache with data?
 
-* **prefix:** prefix keys, default "cache" (use the prefixLayer as first mutateKeys)
-
-* **serialize:** if it is true, the data will be serialized and deserialized JSON (use the jsonSerialize as last mutateValues)
-
-* **webStorage:** local for localStorage, session for sessionStorage. default local
-
-* **disablePersist:** if it is true, nostorage is used
-
-* **mutateKeys:** it is possible to configure which functions will change the keys (eg filterKeys)
-
-* **mutateValues:** it is possible to configure which functions will change the values (eg filterKeys)
-
-* **throttle:** waiting time for data storage
-
-* **errorHandling:** callback performed in case of errors during store saving
-
-
-## Usage default
 ```ts
 import { Cache } from "@wora/cache-persist";
-const cache = new Cache();
-cache.restore().then(() => {
-    const state = cache.getState();
+const initialState = {
+  name: "lorenzo",
+}
+
+const cache = new Cache({
+  initialState,
 });
+// ...
+await cache.restore();
+// ...
+const name = cache.get('name');
 ```
 
-## Usage indexedDB
+### There is data in the storage that is not compatible with the new version of the application, how can I migrate it?
+
+```ts
+import { Cache } from "@wora/cache-persist";
+const initialState = {
+  name: "lorenzo",
+};
+
+const  mergeState = (restoredState, initialState) => {
+  const migrationState = // your logic 
+  return migrationState;
+};
+
+const cache = new Cache({
+  initialState,
+  mergeState
+});
+// ...
+await cache.restore();
+// ...
+const name = cache.get('name');
+```
+
+### How can I use the same storage to manage different states? (e.g. different state based on the logged in user)
+
+```ts
+import { Cache } from "@wora/cache-persist";
+
+export const cacheApp = new Cache({
+   prefix: 'app'
+});
+
+export getUserCache = async (user: string) => {
+  const cacheUser = new Cache({
+     prefix: user
+  });
+  await cacheUser.restore();
+  return cacheUser;
+}
+
+// ...
+await cacheApp.restore();
+// ...
+```
+
+### How can I use indexedDB?
 
 ```ts
 import {Cache, CacheStorage, CacheOptions } from "@wora/cache-persist";
@@ -163,69 +169,95 @@ import { IDBStorage } from '@wora/cache-persist/lib/idbstorage';
 
 const idbStorages: CacheStorage[] = IDBStorage.create( {
     name: "cache", 
-    storeNames: ["persist", "persist2"]
+    storeNames: ["persist"]
 });
 
 const idb: CacheOptions = {
-        storage: idbStorages[0],
-        serialize: false,
-    }
+    storage: idbStorages[0],
+    serialize: false,
+}
 
-const idb1: CacheOptions = {
-        storage: idbStorages[1],
-        serialize: false,
-    }
+const cache = new Cache(idb);
 
-const cacheidb = new Cache(idb);
-cacheidb.restore().then(() => {
-    const state = cacheidb.getState();
-});
-
-const cacheidb1 = new Cache(idb1);
-cacheidb1.restore().then(() => {
-    const state = cacheidb1.getState();
-});
+// ...
+await cache.restore();
+cache.set('name', 'lorenzo');
+const name = cache.get('name')
 ```
 
-### Example use filterKeys Layer
+### How can I use session storage?
 
 ```ts
-import { filterKeys }  from '@wora/cache-persist/lib/layers/filterKeys';
+import { Cache } from "@wora/cache-persist";
+
+const cache = new Cache({
+  webStorage: 'session',
+});
+// ...
+await cache.restore();
+// ...
+const name = cache.get('name');
+```
+
+### How can I prevent some state data from being saved within the storage?
+
+```ts
+import { filterKeys } from '@wora/cache-persist/lib/layers/filterKeys';
 import { IMutateKey } from '@wora/cache-persist';
 
-const filterPersistAuth: IMutateKey = filterKeys(key => key.includes("auth"));
+const filterNoPersist: IMutateKey = filterKeys(key => !key.includes("exclude"));
 
-const filterNoPersistAuth: IMutateKey = filterKeys(key => !key.includes("auth"));
-
-const CacheLocal1 = new Cache({
-    mutateKeys: [filterNoPersistAuth],
-    prefix: 'cache1',
+const cache = new Cache({
+    mutateKeys: [filterNoPersist],
 });
+// ...
 
-const CacheLocal2 = new Cache({
-    mutateKeys: [filterPersistAuth],
-    prefix: 'cache2',
-});
+await cache.restore();
+
+cache.set('include', 'persist');
+cache.set('exclude', 'do not persist');
 ```
 
-## Subscribe and notify example with hooks
+### How can I encrypt the data before it is saved in the storage?
 
 ```ts
-import * as React from 'react';
-import { useEffect, useState } from 'react';
-import { DataCache } from '@wora/cache-persist';
+import { Cache, IMutateValue, mutateValuesLayer } from '@wora/cache-persist';
 
-const [result, setResult] = useState<{loading: boolean, data: DataCache}>({loading: true, data: {}});
+export const encrypt: IMutateValue = mutateValues(
+    (value) => crypt(value),
+    (value) => decrypt(value),
+);
 
- useEffect(() => {
-    const dispose = cache.subscribe((state, action) => {
-      setResult({loading: false, data: state});
-    });
-    cache.restore().then(() => {
-      cache.notify({ action: "restored" });
-    })
-    return () => dispose();
-    
-  },
-    []);
+const cache = new Cache({
+    mutateValues: [encrypt],
+});
+// ...
+
+await cache.restore();
+
+cache.set('name', 'lorenzo');
 ```
+
+### How do I handle storage errors when saving data?
+
+```ts
+import { Cache } from '@wora/cache-persist';
+
+const errorHandling = (cache: Cache, error: Error) => {
+  // your logic
+};
+
+const cache = new Cache({
+    errorHandling,
+});
+// ...
+
+await cache.restore();
+
+cache.set('name', 'lorenzo');
+```
+
+
+## What’s next
+For those interested in knowing how it was implemented, I recommend reading: 
+[State persistence in JavaScript — wora/cache-persist — Deep into its Source Code](https://medium.com/@morrys/state-persistence-in-javascript-wora-cache-persist-deep-into-its-source-code-56fb86147053)

--- a/docs/Caching-CachePersist.md
+++ b/docs/Caching-CachePersist.md
@@ -3,11 +3,35 @@ id: cache-persist
 title: Cache Persist
 ---
 
-As already mentioned, this library allows you, with very little effort of work, to manage the state within your application and its persistence in storage.
+**wora/cache-persist** allows you, with very little effort of work, to manage the state within your application and its persistence in storage.
 
 All you need to know to use it is the **Cache class** and the **configurations** it makes available to you.
 
-So why wait, let’s start right now by viewing the wora/cache-persist Cache:
+Let’s start right now by viewing the wora/cache-persist Cache:
+
+```ts
+export interface ICache {
+    // functions to read
+    get(key: string): any;
+    getState(): Readonly<DataCache>;
+    getAllKeys(): Array<string>;
+    has(key: string): boolean;
+    // functions to write
+    set(key: string, value: any): void;
+    delete(key: string): void;
+    remove(key: string): void;
+    purge(): void;
+    replace(data: any): void;
+    // functions to manage persistence
+    isRehydrated(): boolean;
+    restore(): Promise<DataCache>;
+    flush(): Promise<void>;
+}
+
+export type DataCache = {
+    [key: string]: any;
+};
+```
 
 As you can see from the interface above, there are 3 categories of functions:
 
@@ -23,7 +47,7 @@ As you can see from the interface above, there are 3 categories of functions:
 
 Well, now we can see how to use the cache within our application.
 
-First, let’s install the packages we need:
+### First, let’s install the packages we need:
 
  * wora/cache-persist using yarn or npm:
 
@@ -31,7 +55,7 @@ First, let’s install the packages we need:
 yarn add @wora/cache-persist
 ```
 
-Now, I can show you the simplest use case:
+### Now, I can show you the simplest use case:
 
 ```ts
 import { Cache } from "@wora/cache-persist";

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "react": "16.8.3",
         "rimraf": "2.6.3",
         "promise-polyfill": "6.1.0",
-        "fbjs": "^3.0.0"
+        "fbjs": "^3.0.0",
+        "tslib": "^1.11.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "packages/*"
     ],
     "devDependencies": {
+        "@babel/runtime": "^7.7.2",
         "@types/jest": "24.0.18",
         "ts-jest": "24.1.0",
         "jest": "24.9.0",
@@ -41,6 +42,7 @@
         "react-native": "0.59.8",
         "react": "16.8.3",
         "rimraf": "2.6.3",
-        "promise-polyfill": "6.1.0"
+        "promise-polyfill": "6.1.0",
+        "fbjs": "^3.0.0"
     }
 }

--- a/packages/apollo-offline/src/ApolloClientOffline.ts
+++ b/packages/apollo-offline/src/ApolloClientOffline.ts
@@ -5,7 +5,6 @@ import observableToPromise, { Options } from 'apollo-client/util/observableToPro
 import { getOperationName } from 'apollo-utilities';
 import { CacheOptions } from '@wora/cache-persist';
 import { OfflineFirst, OfflineFirstOptions, OfflineRecordCache } from '@wora/offline-first';
-import { ApolloCache } from '@wora/apollo-cache';
 import { NormalizedCacheObject } from 'apollo-cache-inmemory';
 import { MutationOptions } from 'apollo-client/core/watchQueryOptions';
 import { v4 as uuid } from 'uuid';
@@ -20,7 +19,7 @@ export class ApolloClientOffline extends ApolloClient<NormalizedCacheObject> {
     private promisesRestore;
 
     constructor(apolloOptions: OfflineApolloClientOptions, persistOptions: CacheOptions = {}) {
-        super(apolloOptions);
+        super(apolloOptions as any);
         (this.queryManager as any).isOnline = (): boolean => this.isOnline();
         const persistOptionsStoreOffline = {
             prefix: 'apollo-offline',
@@ -62,7 +61,7 @@ export class ApolloClientOffline extends ApolloClient<NormalizedCacheObject> {
 
     public hydrate(): Promise<boolean> {
         if (!this.promisesRestore) {
-            this.promisesRestore = Promise.all([this.getStoreOffline().hydrate(), (this.cache as ApolloCache).hydrate()])
+            this.promisesRestore = Promise.all([this.getStoreOffline().hydrate(), (this.cache as any).hydrate()])
                 .then((_result) => {
                     (this.cache as any).broadcastWatches();
                     this.queryManager.broadcastQueries();

--- a/packages/cache-persist/README.md
+++ b/packages/cache-persist/README.md
@@ -12,4 +12,4 @@ yarn add @wora/cache-persist
 
 ## Documentation
 
-Follow the link: [Cache Persist Documentation](https://github.com/morrys/wora/blob/master/docs/Caching-CachePersist.md)
+Follow the link: [Cache Persist Documentation](https://morrys.github.io/wora/docs/cache-persist)

--- a/packages/cache-persist/package.json
+++ b/packages/cache-persist/package.json
@@ -36,8 +36,6 @@
     "idb": "^4.0.0"
   },
   "devDependencies": {
-    "rimraf": "2.6.3",
-    "typescript": "3.5.2",
     "@react-native-community/async-storage": "^1.6.1",
     "tslib": "^1.11.1"
   }

--- a/packages/netinfo/package.json
+++ b/packages/netinfo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/netinfo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "keywords": [
     "wora",
     "react-native",

--- a/packages/netinfo/package.json
+++ b/packages/netinfo/package.json
@@ -32,7 +32,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "fbjs": "^1.0.0"
+    "fbjs": "^3.0.0"
   },
   "devDependencies": {
     "@react-native-community/netinfo": "5.7.1"

--- a/packages/offline-first/package.json
+++ b/packages/offline-first/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@wora/netinfo": "file:../netinfo",
     "@wora/cache-persist": "file:../cache-persist",
-    "fbjs": "^1.0.0"
+    "fbjs": "^3.0.0"
   },
   "devDependencies": {}
 }

--- a/packages/offline-first/package.json
+++ b/packages/offline-first/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/offline-first",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "keywords": [
     "cache",
     "wora",

--- a/packages/offline-first/src/index.ts
+++ b/packages/offline-first/src/index.ts
@@ -107,7 +107,11 @@ export class OfflineFirst<T> {
                     const { isConnected } = result[0];
                     this.online = isConnected;
                     if (isConnected && !this.isManualExecution()) {
-                        this.process();
+                        return this.process().then(() => {
+                            this.notify();
+                            this.rehydrated = true;
+                            return true;
+                        });
                     }
                     this.notify();
                     this.rehydrated = true;

--- a/packages/relay-offline/__tests__/fetchQuery-test.ts
+++ b/packages/relay-offline/__tests__/fetchQuery-test.ts
@@ -49,8 +49,8 @@ describe('fetchQuery', () => {
             await environment.mock.hydrate();
             expect(environment.execute.mock.calls.length).toBe(1);
             const args = environment.execute.mock.calls[0][0];
-            expect(args).toEqual({ operation, cacheConfig });
-            expect(args.cacheConfig).toBe(cacheConfig);
+            const checkOperation = createOperationDescriptor(query, variables, cacheConfig);
+            expect(args).toEqual({ operation: checkOperation });
         });
 
         it('resolves with the query results after first value', async () => {
@@ -111,8 +111,8 @@ describe('fetchQuery', () => {
             fetchQuery(environment, query, variables, cacheConfig);
             expect(environment.execute.mock.calls.length).toBe(1);
             const args = environment.execute.mock.calls[0][0];
-            expect(args).toEqual({ operation, cacheConfig });
-            expect(args.cacheConfig).toBe(cacheConfig);
+            const operationCache = createOperationDescriptor(query, variables, cacheConfig);
+            expect(args).toEqual({ operation: operationCache });
         });
 
         it('resolves with the query results after first value', async () => {

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-offline",
-  "version": "3.3.0",
+  "version": "4.0.0-rc.1",
   "keywords": [
     "wora",
     "cache-persist",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.2",
-    "@types/relay-runtime": "^10.1.2",
+    "@types/relay-runtime": "^10.1.6",
     "babel-plugin-relay": "^10.0.0",
     "relay-runtime": "^10.1.0",
     "relay-test-utils-internal" : "^10.1.0",

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -46,10 +46,10 @@
     "relay-runtime": ">=8.0.0"
   },
   "devDependencies": {
-    "babel-plugin-relay": "9.1.0",
-    "relay-runtime": "9.1.0",
-    "relay-test-utils": "9.1.0",
-    "relay-test-utils-internal": "9.0.0"
+    "babel-plugin-relay": "^10.0.0",
+    "relay-runtime": "^10.0.0",
+    "relay-test-utils": "^10.0.0",
+    "relay-test-utils-internal": "^10.0.0"
   },
   "gitHead": "0ceaff4e89ec8a1a5b5547b803f67bcb9166c5af"
 }

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -32,24 +32,26 @@
     "compile": "tsc",
     "format": "prettier --write \"src/**/*.{j,t}s*\"",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "test": "jest --coverage"
+    "test": "jest --coverage -t"
   },
   "dependencies": {
     "@wora/cache-persist": "file:../cache-persist",
     "@wora/offline-first": "file:../offline-first",
     "@wora/relay-store": "file:../relay-store",
-    "fbjs": "^1.0.0",
+    "fbjs": "^3.0.0",
     "uuid": "3.3.2",
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "relay-runtime": ">=8.0.0"
+    "relay-runtime": "^10.1.0"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.7.2",
+    "@types/relay-runtime": "^10.1.2",
     "babel-plugin-relay": "^10.0.0",
-    "relay-runtime": "^10.0.0",
-    "relay-test-utils": "^10.0.0",
-    "relay-test-utils-internal": "^10.0.0"
+    "relay-runtime": "^10.1.0",
+    "relay-test-utils-internal" : "^10.1.0",
+    "relay-test-utils": "^10.1.0"
   },
   "gitHead": "0ceaff4e89ec8a1a5b5547b803f67bcb9166c5af"
 }

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-offline",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0",
   "keywords": [
     "wora",
     "cache-persist",

--- a/packages/relay-offline/src/Environment.ts
+++ b/packages/relay-offline/src/Environment.ts
@@ -71,9 +71,9 @@ export class Environment extends RelayEnvironment {
         const {
             request: { payload },
         } = offline;
-        const { operation, uploadables } = payload;
-        const request = operation.request; // ? operation.request : operation;
-        const netCacheConfig = operation.request.cacheConfig || { force: true }; //|| cacheConfig
+        const { operation, uploadables, cacheConfig } = payload as any;
+        const request: any = operation.request ? operation.request : operation;
+        const netCacheConfig = request.cacheConfig || cacheConfig || { force: true };
         netCacheConfig.metadata = {
             ...netCacheConfig.metadata,
             offline,

--- a/packages/relay-offline/src/EnvironmentIDB.ts
+++ b/packages/relay-offline/src/EnvironmentIDB.ts
@@ -2,7 +2,6 @@ import { ICacheStorage, CacheOptions } from '@wora/cache-persist';
 import { IDBStorage, IOnUpgrade } from '@wora/cache-persist/lib/idbstorage';
 import { Store, RecordSource, StoreOptions } from '@wora/relay-store';
 import { Environment } from './Environment';
-import { CacheOptionsStore } from '@wora/relay-store/lib/Store';
 import { EnvironmentOfflineConfig } from './RelayOfflineTypes';
 
 class EnvironmentIDB {
@@ -15,7 +14,7 @@ class EnvironmentIDB {
         } = {},
         recordSourceOptions: CacheOptions = {},
         storeOptions: {
-            persistOptions?: CacheOptionsStore;
+            persistOptions?: CacheOptions;
             options?: StoreOptions;
         } = {},
         offlineStoreOptions: CacheOptions = {},

--- a/packages/relay-offline/src/RelayOfflineTypes.ts
+++ b/packages/relay-offline/src/RelayOfflineTypes.ts
@@ -1,4 +1,4 @@
-import { Network, OperationDescriptor, UploadableMap, Snapshot, CacheConfig } from 'relay-runtime';
+import { OperationDescriptor, UploadableMap, Snapshot, INetwork } from 'relay-runtime';
 import { OfflineFirstOptions, OfflineRecordCache } from '@wora/offline-first';
 import { EnvironmentConfig } from 'relay-runtime/lib/store/RelayModernEnvironment';
 
@@ -6,12 +6,11 @@ export type Payload = {
     operation: OperationDescriptor;
     optimisticResponse?: { [key: string]: any };
     uploadables?: UploadableMap | null;
-    cacheConfig?: CacheConfig | null | undefined;
 };
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type OfflineOptions<T> = Omit<OfflineFirstOptions<T>, 'execute' | 'onComplete' | 'onDiscard'> & {
-    network?: Network;
+    network?: INetwork;
     onComplete?: (options: { id: string; offlinePayload: OfflineRecordCache<T>; snapshot: Snapshot; response: any }) => Promise<boolean>;
     onDiscard?: (options: { id: string; offlinePayload: OfflineRecordCache<T>; error: Error }) => Promise<boolean>;
 };

--- a/packages/relay-store/README.md
+++ b/packages/relay-store/README.md
@@ -32,6 +32,6 @@ await store.hydrate();
 ```
 
 
-### Options
+## Documentation
 
-[CacheOptions](https://github.com/morrys/wora/blob/master/packages/cache-persist/README.md)
+Follow the link: [Relay Store Documentation](https://morrys.github.io/wora/docs/relay-store)

--- a/packages/relay-store/__tests__/Store-persisted-test.ts
+++ b/packages/relay-store/__tests__/Store-persisted-test.ts
@@ -83,17 +83,42 @@ describe(`Relay Store with ${ImplementationName} Record Source`, () => {
             initialData = simpleClone(data);
 
             const operation = createOperationDescriptor(UserQuery, { id: '4', size: 32 });
-            const id = getID(operation);
+            const id = operation.request.identifier;
             const storeData = {
                 [id]: {
                     selector: operation.root,
                     retainTime: Date.now(),
-                    dispose: true,
+                    dispose: false,
                     ttl: 10000,
                 },
             };
             source = getRecordSourceImplementation(data);
-            store = new RelayModernStore(source, { storage: createPersistedStorage(storeData, 'relay-store'), defaultTTL: -1 });
+            store = new RelayModernStore(
+                source,
+                {
+                    storage: createPersistedStorage(storeData, 'relay-store'),
+                    mergeState: (restoredState, initialState) => {
+                        return Object.keys(restoredState).reduce((acc, key) => {
+                            console.log('acc', acc, key);
+                            const previous = acc[key];
+                            if (previous.selector) {
+                                acc[key] = {
+                                    ...previous,
+                                    operation: {
+                                        root: previous.selector,
+                                    },
+                                    dispose: true,
+                                    refCount: 0,
+                                    fetchTime: previous.retainTime,
+                                };
+                            }
+
+                            return acc;
+                        }, restoredState);
+                    },
+                },
+                { queryCacheExpirationTime: -1 },
+            );
             await store.hydrate();
         });
 
@@ -148,7 +173,7 @@ describe(`Relay Store with ${ImplementationName} Record Source`, () => {
             initialData = simpleClone(data);
 
             const operation = createOperationDescriptor(UserQuery, { id: '4', size: 32 });
-            const id = getID(operation);
+            const id = operation.request.identifier;
             const storeData = {
                 [id]: {
                     operation: operation,
@@ -160,7 +185,11 @@ describe(`Relay Store with ${ImplementationName} Record Source`, () => {
                 },
             };
             source = getRecordSourceImplementation(data);
-            store = new RelayModernStore(source, { storage: createPersistedStorage(storeData, 'relay-store'), defaultTTL: -1 });
+            store = new RelayModernStore(
+                source,
+                { storage: createPersistedStorage(storeData, 'relay-store') },
+                { queryCacheExpirationTime: -1 },
+            );
             await store.hydrate();
         });
 
@@ -1171,5 +1200,4 @@ describe(`Relay Store with ${ImplementationName} Record Source`, () => {
                 },
             });
         });*/
-    });
 });

--- a/packages/relay-store/__tests__/Store-relay-original-test.ts
+++ b/packages/relay-store/__tests__/Store-relay-original-test.ts
@@ -56,7 +56,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                 };
                 initialData = simpleClone(data);
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
                 ({ UserQuery } = generateAndCompile(`
                 query UserQuery($id: ID!, $size: Int) {
                     node(id: $id) {
@@ -147,7 +147,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                     },
                 };
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
                 ({ UserFragment, UserQuery } = generateAndCompile(`
                     fragment UserFragment on User {
                         name
@@ -180,6 +180,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         ...data,
                     },
                     isMissingData: false,
+                    missingRequiredFields: null,
                 });
                 for (const id in snapshot.seenRecords) {
                     if (snapshot.seenRecords.hasOwnProperty(id)) {
@@ -230,6 +231,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         ...data,
                     },
                     isMissingData: false,
+                    missingRequiredFields: null,
                 });
                 expect(snapshot.data.__fragmentOwner).toBe(owner.request); // expect(snapshot.data?.__fragmentOwner).toBe(owner.request);
                 for (const id in snapshot.seenRecords) {
@@ -281,6 +283,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         'client:2': nextData['client:2'],
                     },
                     isMissingData: false,
+                    missingRequiredFields: null,
                 });
             });
         });
@@ -314,7 +317,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                     },
                 };
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: 1 });
                 ({ UserFragment, UserQuery } = generateAndCompile(`
           fragment UserFragment on User {
             name
@@ -530,7 +533,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                     },
                 };
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
                 const owner = createOperationDescriptor(UserQuery, {});
                 const selector = createReaderSelector(UserFragment, '4', { size: 32 }, owner.request);
                 const snapshot = store.lookup(selector);
@@ -552,6 +555,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                 expect(callback.mock.calls[0][0]).toEqual({
                     ...snapshot,
                     isMissingData: false,
+                    missingRequiredFields: null,
                     data: {
                         name: 'Zuck',
                         profilePicture: {
@@ -757,7 +761,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                     },
                 };
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
                 environment = createMockEnvironment({ store });
                 ({ UserQuery } = generateAndCompile(`
           fragment UserFragment on User {
@@ -813,7 +817,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                 // $FlowFixMe found deploying v0.109.0
                 delete data['client:1']; // profile picture
                 source = getRecordSourceImplementation(data);
-                store = new RelayModernStore(source, { defaultTTL: -1 });
+                store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
                 const operation = createOperationDescriptor(UserQuery, {
                     id: '4',
                     size: 32,
@@ -1688,7 +1692,8 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
             callbacks = [];
             scheduler = jest.fn(callbacks.push.bind(callbacks));
             source = getRecordSourceImplementation(data);
-            store = new RelayModernStore(source, { defaultTTL: -1 }, { gcScheduler: scheduler });
+            store = new RelayModernStore(source, undefined, { gcScheduler: scheduler, queryCacheExpirationTime: null });
+            console.log('store', store._cache.getState());
             ({ UserQuery } = generateAndCompile(`
                 fragment UserFragment on User {
                     name
@@ -1749,7 +1754,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
             };
             initialData = simpleClone(data);
             source = getRecordSourceImplementation(data);
-            store = new RelayModernStore(source, { defaultTTL: -1 });
+            store = new RelayModernStore(source, undefined, { queryCacheExpirationTime: null });
             ({ UserQuery } = generateAndCompile(`
                     fragment UserFragment on User {
                         name

--- a/packages/relay-store/__tests__/Store-relay-original-test.ts
+++ b/packages/relay-store/__tests__/Store-relay-original-test.ts
@@ -1693,7 +1693,6 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
             scheduler = jest.fn(callbacks.push.bind(callbacks));
             source = getRecordSourceImplementation(data);
             store = new RelayModernStore(source, undefined, { gcScheduler: scheduler, queryCacheExpirationTime: null });
-            console.log('store', store._cache.getState());
             ({ UserQuery } = generateAndCompile(`
                 fragment UserFragment on User {
                     name

--- a/packages/relay-store/__tests__/Store-time-to-live-test.ts
+++ b/packages/relay-store/__tests__/Store-time-to-live-test.ts
@@ -57,7 +57,7 @@ describe(`Relay Store with ${ImplementationName} Record Source`, () => {
             };
             initialData = simpleClone(data);
             source = getRecordSourceImplementation(data);
-            store = new RelayModernStore(source, { storage: createPersistedStorage(), defaultTTL: 100 });
+            store = new RelayModernStore(source, { storage: createPersistedStorage() }, { queryCacheExpirationTime: 100 });
             await store.hydrate();
             ({ UserQuery } = generateAndCompile(`
             query UserQuery($id: ID!, $size: [Int]) {

--- a/packages/relay-store/package.json
+++ b/packages/relay-store/package.json
@@ -36,12 +36,15 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "relay-runtime": ">=8.0.0"
+    "relay-runtime": "^10.1.0"
   },
   "devDependencies": {
-    "relay-runtime": "^10.0.0",
-    "relay-test-utils-internal" : "^10.0.0",
-    "relay-test-utils": "^10.0.0"
+    
+    "@babel/runtime": "^7.7.2",
+    "@types/relay-runtime": "^10.1.2",
+    "relay-runtime": "^10.1.0",
+    "relay-test-utils-internal" : "^10.1.0",
+    "relay-test-utils": "^10.1.0"
   },
   "gitHead": "07b6de318f2db9d94622d54be6c60940871f3629"
 }

--- a/packages/relay-store/package.json
+++ b/packages/relay-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-store",
-  "version": "3.2.0",
+  "version": "4.0.0-rc.1",
   "keywords": [
     "cache",
     "wora",
@@ -41,7 +41,7 @@
   "devDependencies": {
     
     "@babel/runtime": "^7.7.2",
-    "@types/relay-runtime": "^10.1.2",
+    "@types/relay-runtime": "^10.1.6",
     "relay-runtime": "^10.1.0",
     "relay-test-utils-internal" : "^10.1.0",
     "relay-test-utils": "^10.1.0"

--- a/packages/relay-store/package.json
+++ b/packages/relay-store/package.json
@@ -39,9 +39,9 @@
     "relay-runtime": ">=8.0.0"
   },
   "devDependencies": {
-    "relay-runtime": "^9.1.0",
-    "relay-test-utils-internal" : "9.0.0",
-    "relay-test-utils": "9.1.0"
+    "relay-runtime": "^10.0.0",
+    "relay-test-utils-internal" : "^10.0.0",
+    "relay-test-utils": "^10.0.0"
   },
   "gitHead": "07b6de318f2db9d94622d54be6c60940871f3629"
 }

--- a/packages/relay-store/package.json
+++ b/packages/relay-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-store",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0",
   "keywords": [
     "cache",
     "wora",

--- a/packages/relay-store/src/RecordSource.ts
+++ b/packages/relay-store/src/RecordSource.ts
@@ -21,6 +21,10 @@ export class RecordSource implements IMutableRecordSourceOffline {
         this._cache = new Cache(persistOptionsRecordSource);
     }
 
+    public isRehydrated(): boolean {
+        return this._cache.isRehydrated();
+    }
+
     public purge(): Promise<void> {
         this._cache.purge();
         return this._cache.flush();

--- a/packages/relay-store/src/RecordSource.ts
+++ b/packages/relay-store/src/RecordSource.ts
@@ -1,4 +1,5 @@
-import * as RelayRecordState from 'relay-runtime/lib/store/RelayRecordState';
+import RelayRecordState from 'relay-runtime/lib/store/RelayRecordState';
+import { RecordState } from 'relay-runtime';
 import { MutableRecordSource, Record, RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { Cache, ICache, DataCache, CacheOptions } from '@wora/cache-persist';
 
@@ -45,7 +46,7 @@ export class RecordSource implements IMutableRecordSourceOffline {
         return this._cache.getAllKeys();
     }
 
-    public getStatus(dataID: string): RelayRecordState {
+    public getStatus(dataID: string): RecordState {
         const state = this._cache.getState();
         if (!this._cache.has(dataID)) {
             return UNKNOWN;

--- a/packages/relay-store/src/Store.ts
+++ b/packages/relay-store/src/Store.ts
@@ -31,7 +31,7 @@ export class Store extends RelayModernStore {
         }
         super(recordSource, options);
 
-        this.checkGC = (): boolean => true;
+        this.checkGC = (): boolean => this.isRehydrated();
 
         this._cache = new Cache(persistOptionsStore);
         (this._cache as any).values = (): any => {
@@ -56,6 +56,10 @@ export class Store extends RelayModernStore {
 
     public hydrate(): Promise<Cache[]> {
         return Promise.all([this._cache.restore(), (this as any)._recordSource.restore()]);
+    }
+
+    public isRehydrated(): boolean {
+        return this._cache.isRehydrated() && (!(this as any)._recordSource.isRehydrated || (this as any)._recordSource.isRehydrated());
     }
 
     public getTTL(operation: OperationDescriptor): number {

--- a/packages/relay-store/src/Store.ts
+++ b/packages/relay-store/src/Store.ts
@@ -1,17 +1,11 @@
 import { Store as RelayModernStore } from 'relay-runtime';
 import { Disposable, OperationDescriptor, RequestDescriptor, OperationAvailability, OperationLoader } from 'relay-runtime';
 
-import * as RelayReferenceMarker from 'relay-runtime/lib/store/RelayReferenceMarker';
-
 import { Availability } from 'relay-runtime/lib/store/DataChecker';
 import { CheckOptions, Scheduler } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { Cache, CacheOptions } from '@wora/cache-persist';
 import { RecordSource } from './RecordSource';
 import * as DataChecker from 'relay-runtime/lib/store/DataChecker';
-
-export type CacheOptionsStore = CacheOptions & {
-    defaultTTL?: number;
-};
 
 export type StoreOptions = {
     gcScheduler?: Scheduler | null | undefined;
@@ -20,26 +14,30 @@ export type StoreOptions = {
     gcReleaseBufferSize?: number | null | undefined;
     queryCacheExpirationTime?: number | null | undefined;
 };
+const hasOwn = Object.prototype.hasOwnProperty;
 
 export class Store extends RelayModernStore {
     _cache: Cache;
     checkGC: () => boolean;
-    _defaultTTL: number;
 
-    constructor(recordSource: RecordSource, persistOptions: CacheOptionsStore = {}, options?: StoreOptions) {
-        const { defaultTTL = 10 * 60 * 1000 } = persistOptions;
+    constructor(recordSource: RecordSource, persistOptions: CacheOptions = {}, options: StoreOptions = {}) {
         const persistOptionsStore = {
             prefix: 'relay-store',
             serialize: true,
             ...persistOptions,
         };
+        if (!hasOwn.call(options, 'queryCacheExpirationTime')) {
+            options.queryCacheExpirationTime = 10 * 60 * 1000;
+        }
         super(recordSource, options);
 
         this.checkGC = (): boolean => true;
 
-        this._defaultTTL = options && options.queryCacheExpirationTime ? options.queryCacheExpirationTime : defaultTTL;
-
         this._cache = new Cache(persistOptionsStore);
+        (this._cache as any).values = (): any => {
+            return Object.values(this._cache.getState());
+        };
+        (this as any)._roots = this._cache;
     }
 
     public setCheckGC(checkGC = (): boolean => true): void {
@@ -60,18 +58,19 @@ export class Store extends RelayModernStore {
         return Promise.all([this._cache.restore(), (this as any)._recordSource.restore()]);
     }
 
-    public getID(operation: OperationDescriptor): string {
-        return operation.root.node.name + '.' + JSON.stringify(operation.root.variables);
+    public getTTL(operation: OperationDescriptor): number {
+        return operation.request && operation.request.cacheConfig && (operation.request.cacheConfig as any).ttl
+            ? (operation.request.cacheConfig as any).ttl
+            : (this as any)._queryCacheExpirationTime;
     }
 
-    public retain(operation: OperationDescriptor, retainConfig: { ttl?: number } = {}): Disposable {
-        const { ttl = this._defaultTTL } = retainConfig;
+    public retain(operation: OperationDescriptor): Disposable {
+        const ttl = this.getTTL(operation);
 
-        const id = this.getID(operation);
+        const id = operation.request.identifier;
         let disposed = false;
         const dispose = (): void => {
             // Ensure each retain can only dispose once
-
             const root = this._cache.get(id);
             if (disposed || !root) {
                 return;
@@ -80,15 +79,18 @@ export class Store extends RelayModernStore {
             root.refCount -= 1;
             root.dispose = root.refCount === 0;
             this._cache.set(id, root);
+            let toSchedule = false;
             this._cache.getAllKeys().forEach((idCache) => {
                 const { fetchTime, retainTime, ttl, dispose } = this._cache.get(idCache);
                 const checkDate = fetchTime != null ? fetchTime : retainTime;
                 const expired = !this.isCurrent(checkDate, ttl);
+
                 if (dispose && expired) {
+                    toSchedule = true;
                     this._cache.remove(idCache);
                 }
             });
-            (this as any)._scheduleGC();
+            toSchedule && (this as any).scheduleGC();
         };
         const root = this._cache.get(id);
         const refCount = !root || !root.refCount ? 1 : root.refCount + 1;
@@ -105,73 +107,43 @@ export class Store extends RelayModernStore {
         return { dispose };
     }
 
+    /**
+     * Run a full GC synchronously.
+     */
     __gc(): void {
-        if (!this.checkGC()) {
-            return;
-        }
         // Don't run GC while there are optimistic updates applied
-        if ((this as any)._optimisticSource != null) {
+        if ((this as any)._optimisticSource != null || !this.checkGC()) {
             return;
         }
-        const gcRun = this._collect();
+        const gcRun = (this as any)._collect();
         while (!gcRun.next().done) {}
     }
 
-    *_collect(): Generator<void, void, void> {
-        /* eslint-disable no-labels */
-        top: while (true) {
-            const startEpoch = (this as any)._currentWriteEpoch;
-            const references = new Set();
-            // Mark all records that are traversable from a root
-            for (const id of this._cache.getAllKeys()) {
-                const { operation, selector: oldSelector } = this._cache.get(id);
-                const selector = oldSelector || operation.root;
-                RelayReferenceMarker.mark((this as any)._recordSource, selector, references, (this as any)._operationLoader);
-                // Yield for other work after each operation
-                yield;
-
-                // If the store was updated, restart
-                if (startEpoch !== (this as any)._currentWriteEpoch) {
-                    continue top;
-                }
-            }
-
-            const log = (this as any).__log;
-            if (log != null) {
-                log({
-                    name: 'store.gc',
-                    references,
-                });
-            }
-
-            if (references.size === 0) {
-                // Short-circuit if *nothing* is referenced
-                (this as any)._recordSource.clear();
-            } else {
-                // Evict any unreferenced nodes
-                const storeIDs = (this as any)._recordSource.getRecordIDs();
-                for (let ii = 0; ii < storeIDs.length; ii++) {
-                    const dataID = storeIDs[ii];
-                    if (!references.has(dataID)) {
-                        (this as any)._recordSource.remove(dataID);
-                    }
-                }
-            }
+    scheduleGC(): void {
+        if ((this as any)._optimisticSource != null || !this.checkGC()) {
             return;
         }
+        if ((this as any)._gcHoldCounter > 0) {
+            (this as any)._shouldScheduleGC = true;
+            return;
+        }
+        if ((this as any)._gcRun) {
+            return;
+        }
+        (this as any)._gcRun = (this as any)._collect();
+        (this as any)._gcScheduler((this as any)._gcStep);
     }
 
     private isCurrent(fetchTime: number, ttl: number): boolean {
-        return fetchTime + ttl >= Date.now();
+        return ttl && fetchTime + ttl >= Date.now();
     }
 
     check(operation: OperationDescriptor, options?: CheckOptions): OperationAvailability {
         const selector = operation.root;
-        const source = (this as any)._optimisticSource ? (this as any)._optimisticSource : (this as any)._recordSource;
+        const source = (this as any)._optimisticSource ?? (this as any)._recordSource;
         const globalInvalidationEpoch = (this as any)._globalInvalidationEpoch;
 
-        const id = this.getID(operation);
-        const rootEntry = this._cache.get(id);
+        const rootEntry = this._cache.get(operation.request.identifier);
         const operationLastWrittenAt = rootEntry != null ? rootEntry.epoch : null;
 
         // Check if store has been globally invalidated
@@ -179,16 +151,16 @@ export class Store extends RelayModernStore {
             // If so, check if the operation we're checking was last written
             // before or after invalidation occured.
             if (operationLastWrittenAt == null || operationLastWrittenAt <= globalInvalidationEpoch) {
-                // If the operation was written /before/ global invalidation ocurred,
+                // If the operation was written /before/ global invalidation occurred,
                 // or if this operation has never been written to the store before,
                 // we will consider the data for this operation to be stale
-                //  (i.e. not resolvable from the store).
+                // (i.e. not resolvable from the store).
                 return { status: 'stale' };
             }
         }
 
-        const target = options && options.target ? options.target : source;
-        const handlers = options && options.handlers ? options.handlers : [];
+        const target = options?.target ?? source;
+        const handlers = options?.handlers ?? [];
         const operationAvailability = DataChecker.check(
             source,
             target,
@@ -198,52 +170,36 @@ export class Store extends RelayModernStore {
             (this as any)._getDataID,
         );
 
-        return getAvailablityStatus(operationAvailability, operationLastWrittenAt, rootEntry ? rootEntry.fetchTime : undefined);
+        return getAvailabilityStatus(
+            operationAvailability,
+            operationLastWrittenAt,
+            rootEntry?.fetchTime,
+            this.getTTL(operation),
+            this.checkGC(),
+        );
     }
 
     public notify(sourceOperation?: OperationDescriptor, invalidateStore?: boolean): ReadonlyArray<RequestDescriptor> {
         // Increment the current write when notifying after executing
         // a set of changes to the store.
-        (this as any)._currentWriteEpoch = (this as any)._currentWriteEpoch + 1;
 
-        if (invalidateStore === true) {
-            (this as any)._globalInvalidationEpoch = (this as any)._currentWriteEpoch;
-        }
-
-        const source = (this as any).getSource();
-        const updatedOwners = [];
-        (this as any)._subscriptions.forEach((subscription) => {
-            const owner = (this as any)._updateSubscription(source, subscription);
-            if (owner != null) {
-                updatedOwners.push(owner);
-            }
-        });
-        (this as any)._invalidationSubscriptions.forEach((subscription) => {
-            (this as any)._updateInvalidationSubscription(subscription, invalidateStore === true);
-        });
-        (this as any)._updatedRecordIDs = {};
-        (this as any)._invalidatedRecordIDs.clear();
-
-        // If a source operation was provided (indicating the operation
-        // that produced this update to the store), record the current epoch
-        // at which this operation was written.
+        const updateRoot = sourceOperation && this._cache.has(sourceOperation.request.identifier);
+        const result = super.notify(sourceOperation, invalidateStore);
         if (sourceOperation != null) {
             // We only track the epoch at which the operation was written if
             // it was previously retained, to keep the size of our operation
             // epoch map bounded. If a query wasn't retained, we assume it can
             // may be deleted at any moment and thus is not relevant for us to track
             // for the purposes of invalidation.
-            //const id = sourceOperation.request.identifier;
-            const id = this.getID(sourceOperation);
-            const rootEntry = this._cache.get(id); // wora
-            if (rootEntry != null) {
+            if (updateRoot) {
+                const id = sourceOperation.request.identifier;
+                const rootEntry = this._cache.get(id);
                 rootEntry.epoch = (this as any)._currentWriteEpoch;
                 rootEntry.fetchTime = Date.now();
                 this._cache.set(id, rootEntry);
             }
         }
-
-        return updatedOwners;
+        return result;
     }
 }
 
@@ -256,12 +212,23 @@ export class Store extends RelayModernStore {
  * written to the store, this function will return the overall
  * OperationAvailability for the operation.
  */
-function getAvailablityStatus(
-    opearionAvailability: Availability,
+/**
+ * Returns an OperationAvailability given the Availability returned
+ * by checking an operation, and when that operation was last written to the store.
+ * Specifically, the provided Availability of an operation will contain the
+ * value of when a record referenced by the operation was most recently
+ * invalidated; given that value, and given when this operation was last
+ * written to the store, this function will return the overall
+ * OperationAvailability for the operation.
+ */
+function getAvailabilityStatus(
+    operationAvailability: Availability,
     operationLastWrittenAt: number,
     operationFetchTime: number,
+    queryCacheExpirationTime: number,
+    staleForExpiration: boolean,
 ): OperationAvailability {
-    const { mostRecentlyInvalidatedAt, status } = opearionAvailability;
+    const { mostRecentlyInvalidatedAt, status } = operationAvailability;
     if (typeof mostRecentlyInvalidatedAt === 'number') {
         // If some record referenced by this operation is stale, then the operation itself is stale
         // if either the operation itself was never written *or* the operation was last written
@@ -271,14 +238,18 @@ function getAvailablityStatus(
         }
     }
 
+    if (status === 'missing') {
+        return { status: 'missing' };
+    }
+
+    if (operationFetchTime != null && queryCacheExpirationTime != null) {
+        const isStale = operationFetchTime <= Date.now() - queryCacheExpirationTime;
+        if (isStale && staleForExpiration) {
+            return { status: 'stale' };
+        }
+    }
+
     // There were no invalidations of any reachable records *or* the operation is known to have
     // been fetched after the most recent record invalidation.
-    /* eslint-disable indent */
-    return status === 'missing'
-        ? { status: 'missing' }
-        : {
-              status: 'available',
-              fetchTime: operationFetchTime ? operationFetchTime : null,
-          };
-    /* eslint-enable indent */
+    return { status: 'available', fetchTime: operationFetchTime ?? null };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,7 +2134,7 @@
 "@wora/apollo-cache@file:packages/apollo-cache":
   version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-20d00643-f7f1-4de6-acd6-0c2433715bda-1609154836384/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-6f590290-0e6a-48aa-90c4-f967e345c761-1609234458780/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
   version "2.1.0"
@@ -2149,14 +2149,14 @@
 "@wora/offline-first@file:packages/offline-first":
   version "2.3.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-b2b92d5e-1fcb-4347-a5cc-287b563a219f-1609154836382/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-b2b92d5e-1fcb-4347-a5cc-287b563a219f-1609154836382/node_modules/@wora/netinfo"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-4b9ddf1f-77a7-489c-86e6-1b69fe49e9fc-1609234458775/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-4b9ddf1f-77a7-489c-86e6-1b69fe49e9fc-1609234458775/node_modules/@wora/netinfo"
     fbjs "^3.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
   version "4.0.0-rc.1"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-4.0.0-rc.1-41542424-9eca-4187-b53b-2bdc2c43ceb8-1609154836384/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-4.0.0-rc.1-8640ba84-9aca-46fd-96ad-3135f0c74eb8-1609234458781/node_modules/@wora/cache-persist"
     tslib "^1.11.1"
 
 "@wry/context@^0.4.0":
@@ -10029,11 +10029,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 typescript@3.8.3:
   version "3.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,10 +2054,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/relay-runtime@^10.1.2":
-  version "10.1.5"
-  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-10.1.5.tgz#723a730f165639282b427c95013e8308dec53904"
-  integrity sha512-Sjm1Z3WZsDY3CeS2ypq7bz8X4U7h7tup3Gh1zPFaF2n4nKW+zzH9YKu+GgYC/IxwOJcdv1g3GPKsRovRf+OdPw==
+"@types/relay-runtime@^10.1.6":
+  version "10.1.6"
+  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-10.1.6.tgz#fba34fdb5ce836de6522d1502ff68657408bce74"
+  integrity sha512-B5REuBaGMlsXTAyX15D9NawGywVDzNAGPhsU74/gWNDzKEXRCO2rI0Pd1mtSpBVISHCe8SQlrO8qpXfLt3ZdXA==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2134,7 +2134,7 @@
 "@wora/apollo-cache@file:packages/apollo-cache":
   version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-72f91fa2-1b90-4800-b165-c324e7e340d8-1608229011062/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-20d00643-f7f1-4de6-acd6-0c2433715bda-1609154836384/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
   version "2.1.0"
@@ -2142,21 +2142,21 @@
     idb "^4.0.0"
 
 "@wora/netinfo@file:packages/netinfo":
-  version "2.0.0"
+  version "2.1.0"
   dependencies:
-    fbjs "^1.0.0"
+    fbjs "^3.0.0"
 
 "@wora/offline-first@file:packages/offline-first":
-  version "2.2.0"
+  version "2.3.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-eb481cdd-0f49-49e0-b6c2-22ad3f1bbceb-1608229011061/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-eb481cdd-0f49-49e0-b6c2-22ad3f1bbceb-1608229011061/node_modules/@wora/netinfo"
-    fbjs "^1.0.0"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-b2b92d5e-1fcb-4347-a5cc-287b563a219f-1609154836382/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.3.0-b2b92d5e-1fcb-4347-a5cc-287b563a219f-1609154836382/node_modules/@wora/netinfo"
+    fbjs "^3.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
-  version "3.2.0"
+  version "4.0.0-rc.1"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-3.2.0-deb14e56-339a-4696-91ce-1a037812eac6-1608229011064/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-4.0.0-rc.1-41542424-9eca-4187-b53b-2bdc2c43ceb8-1609154836384/node_modules/@wora/cache-persist"
     tslib "^1.11.1"
 
 "@wry/context@^0.4.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,7 +2122,7 @@
 "@wora/apollo-cache@file:packages/apollo-cache":
   version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-70a7a8fe-2252-47b0-9569-9ace49335492-1588329047487/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-8c57a445-69e0-4910-81d8-01c69539880b-1598432219145/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
   version "2.1.0"
@@ -2135,16 +2135,16 @@
     fbjs "^1.0.0"
 
 "@wora/offline-first@file:packages/offline-first":
-  version "2.1.0"
+  version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.1.0-193324da-22c3-4c59-8953-50b31cae9738-1588329047488/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.1.0-193324da-22c3-4c59-8953-50b31cae9738-1588329047488/node_modules/@wora/netinfo"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-34cfc3ae-dad5-418c-bff2-22a9d768409b-1598432219144/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-34cfc3ae-dad5-418c-bff2-22a9d768409b-1598432219144/node_modules/@wora/netinfo"
     fbjs "^1.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
   version "3.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-3.2.0-95fc5a0c-e056-445c-8d50-e769ee5f3555-1588329047490/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-3.2.0-8cf651ca-6ac6-442d-99d8-3b08b9a3be04-1598432219149/node_modules/@wora/cache-persist"
     tslib "^1.11.1"
 
 "@wry/context@^0.4.0":
@@ -2719,10 +2719,10 @@ babel-plugin-macros@^2.0.0:
     cosmiconfig "^5.2.0"
     resolve "^1.10.0"
 
-babel-plugin-relay@9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-9.1.0.tgz#e44573c6ea847951724cd3fea95219b36e759353"
-  integrity sha512-W0+VoCAmyUxxGrtIcsuZ4fr5oxSxoEcOK5qpGAwxczSSZSNN+ACWqqvDFmgyh5B/ZgK7tXWCarU9HekAkdFpZQ==
+babel-plugin-relay@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-10.0.1.tgz#7e0e12768018ed48f22c623cc1db456989c92647"
+  integrity sha512-0tNZFLVitUbNIHb/PuLYCqW3IvxQK8m5MomrOd5fRy4ljG86fV0KLARjedUQhwRQf32ELU7ODgXFazLza4yZYQ==
   dependencies:
     babel-plugin-macros "^2.0.0"
 
@@ -3116,6 +3116,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -3191,6 +3199,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -4424,7 +4441,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^2.2.2, fast-glob@^2.2.6:
+fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
   integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
@@ -4601,6 +4618,14 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -6501,6 +6526,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -7824,6 +7856,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -7837,6 +7876,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -7984,6 +8030,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -8698,10 +8749,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-9.0.0.tgz#821c2fb972598ea8479db27fc5198133babec6c0"
-  integrity sha512-V509bPZMqVvITUcgXFgvO9pcnAKzF7pJXObnxfglOl3JsfJeDwTW1fu/CzPtvk5suxVMK6Cn9fMxZK2GdRXqYQ==
+relay-compiler@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-10.0.1.tgz#d3029a5121cad52e1e55073210365b827cee5f3b"
+  integrity sha512-hrTqh81XXxPB4EgvxPmvojICr0wJnRoumxOsMZnS9dmhDHSqcBAT7+C3+rdGm5sSdNH8mbMcZM7YSPDh8ABxQw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.5.0"
@@ -8710,50 +8761,42 @@ relay-compiler@9.0.0:
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
     babel-preset-fbjs "^3.3.0"
-    chalk "^2.4.1"
-    fast-glob "^2.2.2"
+    chalk "^4.0.0"
     fb-watchman "^2.0.0"
     fbjs "^1.0.0"
+    glob "^7.1.1"
     immutable "~3.7.6"
     nullthrows "^1.1.1"
-    relay-runtime "9.0.0"
+    relay-runtime "10.0.1"
     signedsource "^1.0.0"
-    yargs "^14.2.0"
+    yargs "^15.3.1"
 
-relay-runtime@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-9.0.0.tgz#03633be24dc3c8b56e472062de6f103954e3d296"
-  integrity sha512-bBNeNmwMOnqtCvuPnWdgflFSVwuUbGV7m7os8qHCUCSJ52DT5B/m6K4wisVh3eZ0QWYr7hheRDfmR/3UEdUe5A==
+relay-runtime@10.0.1, relay-runtime@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-10.0.1.tgz#c83bd7e6e37234ece2a62a254e37dd199a4f74f9"
+  integrity sha512-sPYiuosq+5gQ7zXs2EKg2O8qRSsF8vmMYo6SIHEi4juBLg1HrdTEvqcaNztc2ZFmUc4vYZpTbbS4j/TZCtHuyA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
 
-relay-runtime@9.1.0, relay-runtime@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-9.1.0.tgz#d0534007d5c43e7b9653c6f5cc112ffac09c5020"
-  integrity sha512-6FE5YlZpR/b3R/HzGly85V+c4MdtLJhFY/outQARgxXonomrwqEik0Cr34LnPK4DmGS36cMLUliqhCs/DZyPVw==
+relay-test-utils-internal@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-10.0.1.tgz#44194079e1fbbac62ec8ef33c1179ce7f3e850cf"
+  integrity sha512-iBcS5vy3VYICwsJGcmJLZ7TZPP3/QNV50yE19PyqxiKXx75dFANubVrLRJlyPG8ZUX7aBLoc7zgH3NQSdDMAGQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
+    relay-compiler "10.0.1"
+    relay-runtime "10.0.1"
 
-relay-test-utils-internal@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-9.0.0.tgz#df54b6cc937dd4fbd2e8760f2381faf993318349"
-  integrity sha512-xum0Bp/uDOjgbd08MDXJAFi1iOxafhe/B1PM7VU2BZchdzsV8m3z37IT2qm7P2dZVSp4Vuac6QOrJ+s+20roSw==
+relay-test-utils@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-10.0.1.tgz#3864c262153bcd09e21930c4d371ca16c421aeb9"
+  integrity sha512-lcXdvfk6cp/LRChodk4/LW4WyZTltnnzaKeIw+8M4Ht8/1a0R9XI22iyHNpH3jdYdmksyK5xZ1l2pkm7ipXmEA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
-    relay-compiler "9.0.0"
-    relay-runtime "9.0.0"
-
-relay-test-utils@9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-9.1.0.tgz#b516a96c47f905e73f5a577df24d0195f2a65ea6"
-  integrity sha512-fTgtLbV/7nXD9u/Ujevc9ohRaZpsQBtvJogh076bUB+Vcvv4G9TQ1oZLKLXxJTBcnQEEzrgzLHGjrxVGRb548A==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    fbjs "^1.0.0"
-    relay-runtime "9.1.0"
+    relay-runtime "10.0.1"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -9472,7 +9515,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -10324,6 +10367,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -10514,10 +10566,10 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -10563,22 +10615,22 @@ yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
 
-yargs@^14.2.0:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
   dependencies:
-    cliui "^5.0.0"
+    cliui "^6.0.0"
     decamelize "^1.2.0"
-    find-up "^3.0.0"
+    find-up "^4.1.0"
     get-caller-file "^2.0.1"
     require-directory "^2.1.1"
     require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^3.0.0"
+    string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^15.0.1"
+    yargs-parser "^18.1.2"
 
 yargs@^9.0.0:
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.7.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2047,6 +2054,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/relay-runtime@^10.1.2":
+  version "10.1.5"
+  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-10.1.5.tgz#723a730f165639282b427c95013e8308dec53904"
+  integrity sha512-Sjm1Z3WZsDY3CeS2ypq7bz8X4U7h7tup3Gh1zPFaF2n4nKW+zzH9YKu+GgYC/IxwOJcdv1g3GPKsRovRf+OdPw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -2122,7 +2134,7 @@
 "@wora/apollo-cache@file:packages/apollo-cache":
   version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-8c57a445-69e0-4910-81d8-01c69539880b-1598432219145/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.2.0-72f91fa2-1b90-4800-b165-c324e7e340d8-1608229011062/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
   version "2.1.0"
@@ -2137,14 +2149,14 @@
 "@wora/offline-first@file:packages/offline-first":
   version "2.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-34cfc3ae-dad5-418c-bff2-22a9d768409b-1598432219144/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-34cfc3ae-dad5-418c-bff2-22a9d768409b-1598432219144/node_modules/@wora/netinfo"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-eb481cdd-0f49-49e0-b6c2-22ad3f1bbceb-1608229011061/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.2.0-eb481cdd-0f49-49e0-b6c2-22ad3f1bbceb-1608229011061/node_modules/@wora/netinfo"
     fbjs "^1.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
   version "3.2.0"
   dependencies:
-    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-3.2.0-8cf651ca-6ac6-442d-99d8-3b08b9a3be04-1598432219149/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-3.2.0-deb14e56-339a-4696-91ce-1a037812eac6-1608229011064/node_modules/@wora/cache-persist"
     tslib "^1.11.1"
 
 "@wry/context@^0.4.0":
@@ -3533,6 +3545,13 @@ create-react-class@^15.6.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-fetch@^3.0.4:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4512,6 +4531,19 @@ fbjs@^1.0.0:
     core-js "^2.4.1"
     fbjs-css-vars "^1.0.0"
     isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
+fbjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.0.tgz#0907067fb3f57a78f45d95f1eacffcacd623c165"
+  integrity sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==
+  dependencies:
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
@@ -7361,6 +7393,11 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -8749,10 +8786,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-10.0.1.tgz#d3029a5121cad52e1e55073210365b827cee5f3b"
-  integrity sha512-hrTqh81XXxPB4EgvxPmvojICr0wJnRoumxOsMZnS9dmhDHSqcBAT7+C3+rdGm5sSdNH8mbMcZM7YSPDh8ABxQw==
+relay-compiler@10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-10.1.2.tgz#9a770be6ef8dcb090eddcd649962087d268e9806"
+  integrity sha512-MRZWMIyl7f+YvtD9BVsxFcn/5pUlb5p5+YZ7dFzlWVS6ox0wtAvs+CFMSm6zYbxfR+E39E1PWdsGQ2zQxedKBQ==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.5.0"
@@ -8763,40 +8800,40 @@ relay-compiler@10.0.1:
     babel-preset-fbjs "^3.3.0"
     chalk "^4.0.0"
     fb-watchman "^2.0.0"
-    fbjs "^1.0.0"
+    fbjs "^3.0.0"
     glob "^7.1.1"
     immutable "~3.7.6"
     nullthrows "^1.1.1"
-    relay-runtime "10.0.1"
+    relay-runtime "10.1.2"
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-relay-runtime@10.0.1, relay-runtime@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-10.0.1.tgz#c83bd7e6e37234ece2a62a254e37dd199a4f74f9"
-  integrity sha512-sPYiuosq+5gQ7zXs2EKg2O8qRSsF8vmMYo6SIHEi4juBLg1HrdTEvqcaNztc2ZFmUc4vYZpTbbS4j/TZCtHuyA==
+relay-runtime@10.1.2, relay-runtime@^10.1.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-10.1.2.tgz#842577b78f556a52712773a5c328f94bafd71570"
+  integrity sha512-nAMji6xaQ4bPlBZdXwVEDBDmmPZMfmgHHskUpnDVVldhtuu9zUb4bTDYM5Sk4MMBO8uOR5MJqDkEfBkpV02w+A==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    fbjs "^1.0.0"
+    fbjs "^3.0.0"
 
-relay-test-utils-internal@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-10.0.1.tgz#44194079e1fbbac62ec8ef33c1179ce7f3e850cf"
-  integrity sha512-iBcS5vy3VYICwsJGcmJLZ7TZPP3/QNV50yE19PyqxiKXx75dFANubVrLRJlyPG8ZUX7aBLoc7zgH3NQSdDMAGQ==
+relay-test-utils-internal@^10.1.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-10.1.2.tgz#49df1d0a0f94ea716ab37010912d72fa30cf6108"
+  integrity sha512-FvuVaJqrUxdeiU4PHhcOhX/MGcnzv91MGWOj6lVjEBvZ5jSmyBb8xbyd5Gks+7XVIRwqZr7hN3Q3Hr8Vm3Pk5g==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    fbjs "^1.0.0"
-    relay-compiler "10.0.1"
-    relay-runtime "10.0.1"
+    fbjs "^3.0.0"
+    relay-compiler "10.1.2"
+    relay-runtime "10.1.2"
 
-relay-test-utils@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-10.0.1.tgz#3864c262153bcd09e21930c4d371ca16c421aeb9"
-  integrity sha512-lcXdvfk6cp/LRChodk4/LW4WyZTltnnzaKeIw+8M4Ht8/1a0R9XI22iyHNpH3jdYdmksyK5xZ1l2pkm7ipXmEA==
+relay-test-utils@^10.1.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-10.1.2.tgz#374629ea1808f2c31eef92862005c4e9dea8b6ac"
+  integrity sha512-aiVyYZu9A4KaRrCSlOHNlU1P7ZizvE0YECQ1hTYshS/MoaSBTbw3vG8qnysnw9AvliNSgCaF8QQjjSJgUZSaiw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    fbjs "^1.0.0"
-    relay-runtime "10.0.1"
+    fbjs "^3.0.0"
+    relay-runtime "10.1.2"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
# Breaking Change
  * no backward compatibility with relay v8 and v9  
  * removed defaultTTL, now the queryCacheExpirationTime property of the Relay store is used 

# Migration

```ts
mergeState: (restoredState, initialState) => {
    return Object.keys(restoredState).reduce((acc, key) => {
        const previous = acc[key];
        if (previous.selector) {
            acc[key] = {
                ...previous,
                operation: {
                    root: previous.selector,
                },
                dispose: true,
                refCount: 0,
                fetchTime: previous.retainTime,
                ttl: 1
            };
        }

        return acc;
    }, restoredState);
},
```