### PR TITLE
update relay v.11.0.2

### DIFF
--- a/packages/apollo-cache/package.json
+++ b/packages/apollo-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/apollo-cache",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "keywords": [
     "cache",
     "wora",
@@ -13,6 +13,9 @@
   "description": "@wora Apollo Cache",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apollo-offline/package.json
+++ b/packages/apollo-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/apollo-offline",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "wora",
     "cache-persist",
@@ -16,6 +16,9 @@
   "description": "@wora Apollo Offline Capabilities",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cache-persist/package.json
+++ b/packages/cache-persist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/cache-persist",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "cache",
     "react-native",
@@ -14,6 +14,9 @@
   "description": "@wora Cache Persist",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/detect-network/package.json
+++ b/packages/detect-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/detect-network",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "wora",
     "react-native",
@@ -14,6 +14,9 @@
   "description": "@wora Detect Network",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/netinfo/package.json
+++ b/packages/netinfo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/netinfo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "wora",
     "react-native",
@@ -15,6 +15,9 @@
   "description": "@wora NetInfo",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/offline-first/package.json
+++ b/packages/offline-first/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/offline-first",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "keywords": [
     "cache",
     "wora",
@@ -15,6 +15,9 @@
   "description": "@wora Offline First",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-ApplyUpdate-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-ApplyUpdate-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-Check-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-Check-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, createOperationDescriptor } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.ts
@@ -16,7 +16,8 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-CommitPayload-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-CommitPayload-test.ts
@@ -17,7 +17,7 @@ jest.mock('fbjs/lib/warning');
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-Connection-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-Connection-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, getSingularSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutation-WithLocalInvalidation-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutation-WithLocalInvalidation-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 jest.useFakeTimers();
 
 const RelayRecordSource = {

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutation-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutation-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutationWithGlobalInvalidation-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutationWithGlobalInvalidation-test.ts
@@ -16,7 +16,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');;
 jest.useFakeTimers();
 
 const RelayRecordSource = {

--- a/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.ts
+++ b/packages/relay-offline/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.ts
@@ -15,7 +15,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment} from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, getSingularSelector, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 jest.useFakeTimers();
 const RelayRecordSource = {
   create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: {...data}})

--- a/packages/relay-offline/__tests__/RelayOffline-test.ts
+++ b/packages/relay-offline/__tests__/RelayOffline-test.ts
@@ -1,7 +1,7 @@
 import { Store as RelayModernStore, RecordSource, Environment as RelayModernEnvironment } from '../src';
 import { Network as RelayNetwork, Observable as RelayObservable, createOperationDescriptor, createReaderSelector } from 'relay-runtime';
 import { createPersistedStorage } from './Utils';
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 const RelayRecordSource = {
     create: (data?: any) => new RecordSource({ storage: createPersistedStorage(), initialState: { ...data } }),
 };

--- a/packages/relay-offline/__tests__/TestCompiler.ts
+++ b/packages/relay-offline/__tests__/TestCompiler.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+import { TestSchema, parseGraphQLText } from 'relay-test-utils-internal';
+
+import { CodeMarker, CompilerContext, IRTransforms, compileRelayArtifacts } from 'relay-compiler';
+import { GeneratedNode } from 'relay-runtime';
+
+/**
+ * Parses GraphQL text, applies the selected transforms only (or none if
+ * transforms is not specified), and returns a mapping of definition name to
+ * its basic generated representation.
+ */
+export function generateWithTransforms(
+    text: string,
+    transforms?: Array<any> | null,
+): { [key: string]: GeneratedNode } {
+    return generate(
+        text,
+        TestSchema,
+        {
+            commonTransforms: transforms || [],
+            fragmentTransforms: [],
+            queryTransforms: [],
+            codegenTransforms: [],
+            printTransforms: [],
+        },
+        null,
+    );
+}
+
+/**
+ * Compiles the given GraphQL text using the standard set of transforms (as
+ * defined in RelayCompiler) and returns a mapping of definition name to
+ * its full runtime representation.
+ */
+export function generateAndCompile(
+    text: string,
+    schema?: any | null,
+    moduleMap?: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    return generate(text, schema ?? TestSchema, IRTransforms, moduleMap ?? null);
+}
+
+function generate(
+    text: string,
+    schema: any,
+    transforms: any,
+    moduleMap: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    const relaySchema = schema.extend(IRTransforms.schemaExtensions);
+    const { definitions, schema: extendedSchema } = parseGraphQLText(relaySchema, text);
+    const compilerContext = new CompilerContext(extendedSchema).addAll(definitions);
+    const documentMap = {};
+    compileRelayArtifacts(compilerContext, transforms).forEach(([_definition, node]) => {
+        const transformedNode = moduleMap != null ? CodeMarker.transform(node, moduleMap) : node;
+        documentMap[node.kind === 'Request' ? node.params.name : node.name] = transformedNode;
+    });
+    return documentMap;
+}

--- a/packages/relay-offline/__tests__/fetchQuery-test.ts
+++ b/packages/relay-offline/__tests__/fetchQuery-test.ts
@@ -10,12 +10,12 @@
 
 'use strict';
 
-import { fetchQuery } from '../src';
+import { fetchQuery_DEPRECATED as fetchQuery } from '../src';
 
 import { createOperationDescriptor } from 'relay-runtime';
 import { createMockEnvironment } from './RelayModernEnvironmentMock';
 
-const { generateAndCompile } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 //jest.useFakeTimers();
 describe('fetchQuery', () => {
     describe('fetchQuery with hydrate', () => {

--- a/packages/relay-offline/package.json
+++ b/packages/relay-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-offline",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "keywords": [
     "wora",
     "cache-persist",
@@ -17,6 +17,9 @@
   "author": {
     "name": "morrys"
   },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +35,7 @@
     "compile": "tsc",
     "format": "prettier --write \"src/**/*.{j,t}s*\"",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "test": "jest --coverage -t"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@wora/cache-persist": "file:../cache-persist",
@@ -43,15 +46,15 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "relay-runtime": "^10.1.0"
+    "relay-runtime": "^11.0.2"
   },
   "devDependencies": {
     "@babel/runtime": "^7.7.2",
-    "@types/relay-runtime": "^10.1.6",
-    "babel-plugin-relay": "^10.0.0",
-    "relay-runtime": "^10.1.0",
-    "relay-test-utils-internal" : "^10.1.0",
-    "relay-test-utils": "^10.1.0"
+    "@types/relay-runtime": "^11.0.0",
+    "babel-plugin-relay": "^11.0.2",
+    "relay-runtime": "^11.0.2",
+    "relay-test-utils-internal" : "^11.0.2",
+    "relay-test-utils": "^11.0.2"
   },
   "gitHead": "0ceaff4e89ec8a1a5b5547b803f67bcb9166c5af"
 }

--- a/packages/relay-offline/src/Environment.ts
+++ b/packages/relay-offline/src/Environment.ts
@@ -100,7 +100,9 @@ export class Environment extends RelayEnvironment {
                 .then((_result) => {
                     this._rehydrated = true;
                     const updateRecords = (this as any)._store.__getUpdatedRecordIDs();
-                    Object.keys((this as any)._store.getSource().toJSON()).forEach((key) => (updateRecords[key] = true));
+                    Object.keys((this as any)._store.getSource().toJSON()).forEach((key) => {
+                        updateRecords.add(key);
+                    });
                     (this as any)._store.notify();
                     return true;
                 })

--- a/packages/relay-offline/src/Environment.ts
+++ b/packages/relay-offline/src/Environment.ts
@@ -10,7 +10,6 @@ import {
 } from 'relay-runtime';
 
 import { EnvironmentConfig } from 'relay-runtime/lib/store/RelayModernEnvironment';
-import * as RelayModernQueryExecutor from 'relay-runtime/lib/store/RelayModernQueryExecutor';
 
 import { Store } from '@wora/relay-store';
 import { CacheOptions } from '@wora/cache-persist';
@@ -143,68 +142,56 @@ export class Environment extends RelayEnvironment {
         updater?: SelectorStoreUpdater | null;
         uploadables?: UploadableMap | null;
     }): RelayObservable<GraphQLResponse> {
-        return RelayObservable.create((sink) => {
-            let optimisticConfig;
-            if (optimisticResponse || optimisticUpdater) {
-                optimisticConfig = {
-                    operation,
-                    response: optimisticResponse,
-                    updater: optimisticUpdater,
-                };
-            }
-            warning(
-                !!optimisticConfig,
-                'commitMutation offline: no optimistic responses configured. the mutation will not perform any store updates.',
-            );
-            const source = RelayObservable.create<any>((sink) => {
-                resolveImmediate(() => {
-                    const sinkPublish = optimisticConfig ? (this as any).getStore().getSource()._sink.toJSON() : {};
-                    const backup = {};
-                    Object.keys(sinkPublish).forEach((key) => (backup[key] = (this as any).getStore().getSource()._base.get(key)));
-
-                    sink.next({
-                        data: optimisticResponse ? optimisticResponse : {},
-                    });
-
-                    const id = uuid();
-                    const payload: Payload = {
-                        operation,
-                        optimisticResponse,
-                        uploadables,
-                    };
-                    const request: Request<Payload> = {
-                        payload,
-                        backup,
-                        sink: sinkPublish,
-                    };
-                    this.getStoreOffline()
-                        .publish({ id, request, serial: true })
-                        .then((_offlineRecord) => {
-                            this.getStoreOffline().notify();
-                            sink.complete();
-                        })
-                        .catch((error) => {
-                            sink.error(error, true);
-                        });
-                });
-            });
-            const executor = RelayModernQueryExecutor.execute({
+        let optimisticConfig;
+        if (optimisticResponse || optimisticUpdater) {
+            optimisticConfig = {
                 operation,
-                operationExecutions: (this as any)._operationExecutions,
-                operationLoader: (this as any)._operationLoader,
-                optimisticConfig,
-                publishQueue: (this as any)._publishQueue,
-                scheduler: (this as any)._scheduler,
-                sink,
-                source,
-                store: (this as any)._store,
-                updater: optimisticResponse ? updater : optimisticUpdater,
-                operationTracker: (this as any)._operationTracker,
-                getDataID: (this as any)._getDataID,
-                treatMissingFieldsAsNull: (this as any)._treatMissingFieldsAsNull,
-                reactFlightPayloadDeserializer: (this as any)._reactFlightPayloadDeserializer,
+                response: optimisticResponse,
+                updater: optimisticUpdater,
+            };
+        }
+        warning(
+            !!optimisticConfig,
+            'commitMutation offline: no optimistic responses configured. the mutation will not perform any store updates.',
+        );
+        const source = RelayObservable.create<any>((sink) => {
+            resolveImmediate(() => {
+                const sinkPublish = optimisticConfig ? (this as any).getStore().getSource()._sink.toJSON() : {};
+                const backup = {};
+                Object.keys(sinkPublish).forEach((key) => (backup[key] = (this as any).getStore().getSource()._base.get(key)));
+
+                sink.next({
+                    data: optimisticResponse ? optimisticResponse : {},
+                });
+
+                const id = uuid();
+                const payload: Payload = {
+                    operation,
+                    optimisticResponse,
+                    uploadables,
+                };
+                const request: Request<Payload> = {
+                    payload,
+                    backup,
+                    sink: sinkPublish,
+                };
+                this.getStoreOffline()
+                    .publish({ id, request, serial: true })
+                    .then((_offlineRecord) => {
+                        this.getStoreOffline().notify();
+                        sink.complete();
+                    })
+                    .catch((error) => {
+                        sink.error(error, true);
+                    });
             });
-            return (): void => executor.cancel();
+        });
+        return (this as any)._execute({
+            createSource: () => source,
+            isClientPayload: false,
+            operation,
+            optimisticConfig,
+            updater: optimisticResponse ? updater : optimisticUpdater,
         });
     }
 

--- a/packages/relay-offline/src/fetchQuery_DEPRECATED.ts
+++ b/packages/relay-offline/src/fetchQuery_DEPRECATED.ts
@@ -1,8 +1,8 @@
-import { fetchQuery as relayFetchQuery, GraphQLTaggedNode, CacheConfig } from 'relay-runtime';
-import { OperationType } from 'relay-runtime';
+/* eslint-disable @typescript-eslint/camelcase */
+import { fetchQuery_DEPRECATED as relayFetchQuery, GraphQLTaggedNode, CacheConfig, OperationType } from 'relay-runtime';
 import { Environment } from './Environment';
 
-export function fetchQuery<T extends OperationType>(
+export function fetchQuery_DEPRECATED<T extends OperationType>(
     environment: Environment,
     taggedNode: GraphQLTaggedNode,
     variables: T['variables'],

--- a/packages/relay-offline/src/index.ts
+++ b/packages/relay-offline/src/index.ts
@@ -1,5 +1,6 @@
 export { Environment } from './Environment';
-export { fetchQuery } from './fetchQuery';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export { fetchQuery_DEPRECATED } from './fetchQuery_DEPRECATED';
 export { Store } from '@wora/relay-store';
 export { RecordSource } from '@wora/relay-store';
 export * from './RelayOfflineTypes';

--- a/packages/relay-store/__tests__/Store-persisted-test.ts
+++ b/packages/relay-store/__tests__/Store-persisted-test.ts
@@ -4,7 +4,8 @@ import RelayRecordSourceObjectImpl from 'relay-runtime/lib/store/RelayRecordSour
 
 import { getRequest } from 'relay-runtime/lib/query/GraphQLTag';
 import { createOperationDescriptor, createReaderSelector, REF_KEY, ROOT_ID, ROOT_TYPE } from 'relay-runtime';
-const { generateAndCompile, simpleClone } = require('relay-test-utils-internal');
+const { simpleClone } = require('relay-test-utils-internal');
+const { generateAndCompile } = require('./TestCompiler');
 jest.useFakeTimers();
 
 function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {

--- a/packages/relay-store/__tests__/Store-relay-original-test.ts
+++ b/packages/relay-store/__tests__/Store-relay-original-test.ts
@@ -5,7 +5,9 @@ import RelayRecordSourceMapImpl from 'relay-runtime/lib/store/RelayRecordSourceM
 
 import { getRequest } from 'relay-runtime/lib/query/GraphQLTag';
 import { createOperationDescriptor, createReaderSelector, REF_KEY, ROOT_ID, ROOT_TYPE } from 'relay-runtime';
-const { createMockEnvironment, generateAndCompile, simpleClone } = require('relay-test-utils-internal');
+const { createMockEnvironment, simpleClone } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 jest.useFakeTimers();
 
 function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
@@ -176,9 +178,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                             uri: 'https://photo1.jpg',
                         },
                     },
-                    seenRecords: {
-                        ...data,
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                     isMissingData: false,
                     missingRequiredFields: null,
                 });
@@ -227,9 +227,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         __fragments: { ChildUserFragment: {} },
                         __fragmentOwner: owner.request,
                     },
-                    seenRecords: {
-                        ...data,
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                     isMissingData: false,
                     missingRequiredFields: null,
                 });
@@ -278,10 +276,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                             uri: 'https://photo1.jpg',
                         },
                     },
-                    seenRecords: {
-                        '4': { ...data['4'], ...nextData['4'] },
-                        'client:2': nextData['client:2'],
-                    },
+                    seenRecords: new Set(['4', 'client:2']),
                     isMissingData: false,
                     missingRequiredFields: null,
                 });
@@ -362,20 +357,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         },
                         emailAddresses: ['a@b.com'],
                     },
-                    seenRecords: {
-                        '4': {
-                            __id: '4',
-                            id: '4',
-                            __typename: 'User',
-                            name: 'Zuck',
-                            'profilePicture(size:32)': { [REF_KEY]: 'client:1' },
-                            emailAddresses: ['a@b.com'],
-                        },
-                        'client:1': {
-                            ...data['client:1'],
-                            uri: 'https://photo2.jpg',
-                        },
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                 });
             });
 
@@ -424,20 +406,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         },
                         emailAddresses: ['a@b.com'],
                     },
-                    seenRecords: {
-                        '4': {
-                            __id: '4',
-                            id: '4',
-                            __typename: 'User',
-                            name: 'Zuck',
-                            'profilePicture(size:32)': { [REF_KEY]: 'client:1' },
-                            emailAddresses: ['a@b.com'],
-                        },
-                        'client:1': {
-                            ...data['client:1'],
-                            uri: 'https://photo2.jpg',
-                        },
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                 });
                 expect(callback.mock.calls[0][0].selector).toBe(selector);
             });
@@ -504,17 +473,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         },
                         emailAddresses: ['a@b.com', 'c@d.net'],
                     },
-                    seenRecords: {
-                        '4': {
-                            ...data['4'],
-                            name: 'Mark',
-                            emailAddresses: ['a@b.com', 'c@d.net'],
-                        },
-                        'client:1': {
-                            ...data['client:1'],
-                            uri: 'https://photo3.jpg',
-                        },
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                 });
             });
 
@@ -563,15 +522,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         },
                         emailAddresses: ['a@b.com'],
                     },
-                    seenRecords: {
-                        '4': {
-                            ...data['4'],
-                            emailAddresses: ['a@b.com'],
-                        },
-                        'client:1': {
-                            ...data['client:1'],
-                        },
-                    },
+                    seenRecords: new Set(['4', 'client:1']),
                 });
             });
 
@@ -606,7 +557,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         profilePicture: undefined,
                     },
                     isMissingData: true,
-                    seenRecords: nextSource.toJSON(),
+                    seenRecords: new Set(['842472']),
                 });
             });
 
@@ -644,7 +595,7 @@ function assertIsDeeplyFrozen(value: {} | ReadonlyArray<{}>) {
                         profilePicture: undefined,
                     },
                     isMissingData: true,
-                    seenRecords: nextSource.toJSON(),
+                    seenRecords: new Set(['842472']),
                 });
             });
 

--- a/packages/relay-store/__tests__/Store-time-to-live-test.ts
+++ b/packages/relay-store/__tests__/Store-time-to-live-test.ts
@@ -1,7 +1,9 @@
 import { Store as RelayModernStore, RecordSource as WoraRecordSource } from '../src';
 
 import { createOperationDescriptor, REF_KEY, ROOT_ID, ROOT_TYPE } from 'relay-runtime';
-const { generateAndCompile, simpleClone } = require('relay-test-utils-internal');
+const { simpleClone } = require('relay-test-utils-internal');
+
+const { generateAndCompile } = require('./TestCompiler');
 
 jest.useFakeTimers();
 

--- a/packages/relay-store/__tests__/TestCompiler.ts
+++ b/packages/relay-store/__tests__/TestCompiler.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+import { TestSchema, parseGraphQLText } from 'relay-test-utils-internal';
+
+import { CodeMarker, CompilerContext, IRTransforms, compileRelayArtifacts } from 'relay-compiler';
+import { GeneratedNode } from 'relay-runtime';
+
+/**
+ * Parses GraphQL text, applies the selected transforms only (or none if
+ * transforms is not specified), and returns a mapping of definition name to
+ * its basic generated representation.
+ */
+export function generateWithTransforms(
+    text: string,
+    transforms?: Array<any> | null,
+): { [key: string]: GeneratedNode } {
+    return generate(
+        text,
+        TestSchema,
+        {
+            commonTransforms: transforms || [],
+            fragmentTransforms: [],
+            queryTransforms: [],
+            codegenTransforms: [],
+            printTransforms: [],
+        },
+        null,
+    );
+}
+
+/**
+ * Compiles the given GraphQL text using the standard set of transforms (as
+ * defined in RelayCompiler) and returns a mapping of definition name to
+ * its full runtime representation.
+ */
+export function generateAndCompile(
+    text: string,
+    schema?: any | null,
+    moduleMap?: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    return generate(text, schema ?? TestSchema, IRTransforms, moduleMap ?? null);
+}
+
+function generate(
+    text: string,
+    schema: any,
+    transforms: any,
+    moduleMap: { [key: string]: any } | null,
+): { [key: string]: GeneratedNode } {
+    const relaySchema = schema.extend(IRTransforms.schemaExtensions);
+    const { definitions, schema: extendedSchema } = parseGraphQLText(relaySchema, text);
+    const compilerContext = new CompilerContext(extendedSchema).addAll(definitions);
+    const documentMap = {};
+    compileRelayArtifacts(compilerContext, transforms).forEach(([_definition, node]) => {
+        const transformedNode = moduleMap != null ? CodeMarker.transform(node, moduleMap) : node;
+        documentMap[node.kind === 'Request' ? node.params.name : node.name] = transformedNode;
+    });
+    return documentMap;
+}

--- a/packages/relay-store/package.json
+++ b/packages/relay-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wora/relay-store",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "keywords": [
     "cache",
     "wora",
@@ -13,6 +13,9 @@
   "description": "@wora Relay Store",
   "author": {
     "name": "morrys"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/morrys"
   },
   "publishConfig": {
     "access": "public"
@@ -36,15 +39,15 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "relay-runtime": "^10.1.0"
+    "relay-runtime": "^11.0.2"
   },
   "devDependencies": {
     
     "@babel/runtime": "^7.7.2",
-    "@types/relay-runtime": "^10.1.6",
-    "relay-runtime": "^10.1.0",
-    "relay-test-utils-internal" : "^10.1.0",
-    "relay-test-utils": "^10.1.0"
+    "@types/relay-runtime": "^11.0.0",
+    "relay-runtime": "^11.0.2",
+    "relay-test-utils-internal" : "^11.0.2",
+    "relay-test-utils": "^11.0.2"
   },
   "gitHead": "07b6de318f2db9d94622d54be6c60940871f3629"
 }

--- a/packages/relay-store/src/RecordSource.ts
+++ b/packages/relay-store/src/RecordSource.ts
@@ -42,7 +42,7 @@ export class RecordSource implements IMutableRecordSourceOffline {
         this._cache.delete(dataID);
     }
 
-    public get(dataID: string): Record {
+    public get(dataID: string): Record<any> {
         return this._cache.get(dataID);
     }
 

--- a/packages/relay-store/src/Store.ts
+++ b/packages/relay-store/src/Store.ts
@@ -2,17 +2,20 @@ import { Store as RelayModernStore } from 'relay-runtime';
 import { Disposable, OperationDescriptor, RequestDescriptor, OperationAvailability, OperationLoader } from 'relay-runtime';
 
 import { Availability } from 'relay-runtime/lib/store/DataChecker';
-import { CheckOptions, Scheduler } from 'relay-runtime/lib/store/RelayStoreTypes';
+import { CheckOptions, LogFunction, Scheduler } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { Cache, CacheOptions } from '@wora/cache-persist';
 import { RecordSource } from './RecordSource';
 import * as DataChecker from 'relay-runtime/lib/store/DataChecker';
+import { GetDataID } from 'relay-runtime/lib/store/RelayResponseNormalizer';
 
 export type StoreOptions = {
     gcScheduler?: Scheduler | null | undefined;
+    log?: LogFunction | null | undefined;
     operationLoader?: OperationLoader | null | undefined;
-    UNSTABLE_DO_NOT_USE_getDataID?: any | null | undefined;
+    GetDataID?: GetDataID | null | undefined;
     gcReleaseBufferSize?: number | null | undefined;
     queryCacheExpirationTime?: number | null | undefined;
+    shouldProcessClientComponents?: boolean | null | undefined;
 };
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -28,6 +31,9 @@ export class Store extends RelayModernStore {
         };
         if (!hasOwn.call(options, 'queryCacheExpirationTime')) {
             options.queryCacheExpirationTime = 10 * 60 * 1000;
+        }
+        if (!hasOwn.call(options, 'gcReleaseBufferSize')) {
+            options.gcReleaseBufferSize = 0;
         }
         super(recordSource, options);
 
@@ -172,6 +178,7 @@ export class Store extends RelayModernStore {
             handlers,
             (this as any)._operationLoader,
             (this as any)._getDataID,
+            (this as any)._shouldProcessClientComponents,
         );
 
         return getAvailabilityStatus(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2056,10 +2056,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/relay-runtime@^10.1.6":
-  version "10.1.6"
-  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-10.1.6.tgz#fba34fdb5ce836de6522d1502ff68657408bce74"
-  integrity sha512-B5REuBaGMlsXTAyX15D9NawGywVDzNAGPhsU74/gWNDzKEXRCO2rI0Pd1mtSpBVISHCe8SQlrO8qpXfLt3ZdXA==
+"@types/relay-runtime@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-11.0.0.tgz#7ddbe41152d46b614d1f3f7f0672cfb721eb93f1"
+  integrity sha512-D5JNxDhkcPSIMZc2j3N/fh61399O309ph9RVmzbF+Fsyvepsqy7FirFKcJ2CMfYxE/kb8ZD/Xdzs3CYZEiQc4w==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2134,12 +2134,12 @@
     tsutils "^3.17.1"
 
 "@wora/apollo-cache@file:packages/apollo-cache":
-  version "2.2.0"
+  version "2.3.0"
   dependencies:
-    "@wora/cache-persist" "file:../../Library/Caches/Yarn/v6/npm-@wora-apollo-cache-2.2.0-1e7edac8-41ff-46b5-a71d-4fe16e9444c1-1611579151904/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-apollo-cache-2.3.0-2a4fae68-a873-416b-8768-9f2f274711e9-1618910283561/node_modules/@wora/cache-persist"
 
 "@wora/cache-persist@file:packages/cache-persist":
-  version "2.1.0"
+  version "2.2.0"
   dependencies:
     idb "^4.0.0"
 
@@ -2149,16 +2149,16 @@
     fbjs "^3.0.0"
 
 "@wora/offline-first@file:packages/offline-first":
-  version "2.3.0"
+  version "2.4.0"
   dependencies:
-    "@wora/cache-persist" "file:../../Library/Caches/Yarn/v6/npm-@wora-offline-first-2.3.0-bf36c62d-4b58-40c8-a5cc-818b8749c82d-1611579151904/node_modules/@wora/cache-persist"
-    "@wora/netinfo" "file:../../Library/Caches/Yarn/v6/npm-@wora-offline-first-2.3.0-bf36c62d-4b58-40c8-a5cc-818b8749c82d-1611579151904/node_modules/@wora/netinfo"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.4.0-5224d313-87be-46c8-9108-8cf5fd5ad9ed-1618910283559/node_modules/@wora/cache-persist"
+    "@wora/netinfo" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-offline-first-2.4.0-5224d313-87be-46c8-9108-8cf5fd5ad9ed-1618910283559/node_modules/@wora/netinfo"
     fbjs "^3.0.0"
 
 "@wora/relay-store@file:packages/relay-store":
-  version "4.0.0"
+  version "4.1.0"
   dependencies:
-    "@wora/cache-persist" "file:../../Library/Caches/Yarn/v6/npm-@wora-relay-store-4.0.0-70893564-1127-4973-9c39-3ec9282a8309-1611579151905/node_modules/@wora/cache-persist"
+    "@wora/cache-persist" "file:../../../../../Users/lorenzo.digiacomo/AppData/Local/Yarn/Cache/v6/npm-@wora-relay-store-4.1.0-260a7b22-6c45-465a-bf4e-14ca00f433ce-1618910283562/node_modules/@wora/cache-persist"
     tslib "^1.11.1"
 
 "@wry/context@^0.4.0":
@@ -2733,10 +2733,10 @@ babel-plugin-macros@^2.0.0:
     cosmiconfig "^5.2.0"
     resolve "^1.10.0"
 
-babel-plugin-relay@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-10.0.1.tgz#7e0e12768018ed48f22c623cc1db456989c92647"
-  integrity sha512-0tNZFLVitUbNIHb/PuLYCqW3IvxQK8m5MomrOd5fRy4ljG86fV0KLARjedUQhwRQf32ELU7ODgXFazLza4yZYQ==
+babel-plugin-relay@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-relay/-/babel-plugin-relay-11.0.2.tgz#9ef5903226b12767114e12536c28566bddfe3aad"
+  integrity sha512-aUvTq/2wTSP43QMPbzLKXA5UTh8le1iXwZMH8Pi7rPnWzSLCaWfX6Jhy1gPVG2ADj2zjTciUsiGlOFoI3rP0Zw==
   dependencies:
     babel-plugin-macros "^2.0.0"
 
@@ -8796,10 +8796,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@10.1.2:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-10.1.2.tgz#9a770be6ef8dcb090eddcd649962087d268e9806"
-  integrity sha512-MRZWMIyl7f+YvtD9BVsxFcn/5pUlb5p5+YZ7dFzlWVS6ox0wtAvs+CFMSm6zYbxfR+E39E1PWdsGQ2zQxedKBQ==
+relay-compiler@11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-11.0.2.tgz#e1e09a1c881d169a7a524ead728ad6a89c7bd4af"
+  integrity sha512-nDVAURT1YncxSiDOKa39OiERkAr0DUcPmlHlg+C8zD+EiDo2Sgczf2R6cDsN4UcDvucYtkLlDLFErPwgLs8WzA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.5.0"
@@ -8813,37 +8813,40 @@ relay-compiler@10.1.2:
     fbjs "^3.0.0"
     glob "^7.1.1"
     immutable "~3.7.6"
+    invariant "^2.2.4"
     nullthrows "^1.1.1"
-    relay-runtime "10.1.2"
+    relay-runtime "11.0.2"
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-relay-runtime@10.1.2, relay-runtime@^10.1.0:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-10.1.2.tgz#842577b78f556a52712773a5c328f94bafd71570"
-  integrity sha512-nAMji6xaQ4bPlBZdXwVEDBDmmPZMfmgHHskUpnDVVldhtuu9zUb4bTDYM5Sk4MMBO8uOR5MJqDkEfBkpV02w+A==
+relay-runtime@11.0.2, relay-runtime@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-11.0.2.tgz#c3650477d45665b9628b852b35f203e361ad55e8"
+  integrity sha512-xxZkIRnL8kNE1cxmwDXX8P+wSeWLR+0ACFyAiAhvfWWAyjXb+bhjJ2FSsRGlNYfkqaTNEuDqpnodQV1/fF7Idw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
+    invariant "^2.2.4"
 
-relay-test-utils-internal@^10.1.0:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-10.1.2.tgz#49df1d0a0f94ea716ab37010912d72fa30cf6108"
-  integrity sha512-FvuVaJqrUxdeiU4PHhcOhX/MGcnzv91MGWOj6lVjEBvZ5jSmyBb8xbyd5Gks+7XVIRwqZr7hN3Q3Hr8Vm3Pk5g==
+relay-test-utils-internal@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/relay-test-utils-internal/-/relay-test-utils-internal-11.0.2.tgz#0ab9059c838e2291ac54bf48d7f0a15e19d28a39"
+  integrity sha512-kQbmpu8F1u2yqz2bps6REYUYDGeBS0nynUzDfDt7nQqVbH3MRFbH6B9lRU7/SVM/wxgpR90ai3zcEGQRvMLKeg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
-    relay-compiler "10.1.2"
-    relay-runtime "10.1.2"
+    relay-compiler "11.0.2"
+    relay-runtime "11.0.2"
 
-relay-test-utils@^10.1.0:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-10.1.2.tgz#374629ea1808f2c31eef92862005c4e9dea8b6ac"
-  integrity sha512-aiVyYZu9A4KaRrCSlOHNlU1P7ZizvE0YECQ1hTYshS/MoaSBTbw3vG8qnysnw9AvliNSgCaF8QQjjSJgUZSaiw==
+relay-test-utils@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/relay-test-utils/-/relay-test-utils-11.0.2.tgz#95e2bcecc2a11878b5062cf4b27d06395ffc2482"
+  integrity sha512-zyDrKT+1CxzH3U0qHfE6LQlQefd1XCkXPlwH9RALqarthTzE4VpFNFCIz7btDzgRl7WEFTCG84n9lYNp94TXtA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
-    relay-runtime "10.1.2"
+    invariant "^2.2.4"
+    relay-runtime "11.0.2"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
With the release [v11.0.2](https://github.com/facebook/relay/releases/tag/v11.0.2) important changes have been made to the internal relay api. https://github.com/morrys/wora/issues/82

# Improved
* update relay dependency
* renamed fetchQuery to fetchQuery_DEPRECATED, now fetchQuery is an observable so the user must be sure the environment is hydrated before using it 
* removed the use of RelayModernQueryExecutor.execute in favor of the _execute internal function of the environment 

# Tests
* added TestCompiler in order to use generateAndCompile function
* adapted the tests to the new management of the seen records