### PR TITLE
fix: Adjust relay-store types for strict mode

### DIFF
--- a/packages/relay-store/src/RecordSource.ts
+++ b/packages/relay-store/src/RecordSource.ts
@@ -1,6 +1,6 @@
 import RelayRecordState from 'relay-runtime/lib/store/RelayRecordState';
 import { RecordState } from 'relay-runtime';
-import { MutableRecordSource, Record, RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes';
+import { MutableRecordSource, Record } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { Cache, ICache, DataCache, CacheOptions } from '@wora/cache-persist';
 
 const { EXISTENT, NONEXISTENT, UNKNOWN } = RelayRecordState;
@@ -74,7 +74,7 @@ export class RecordSource implements IMutableRecordSourceOffline {
         return this._cache.getAllKeys().length;
     }
 
-    public toJSON(): RecordMap {
+    public toJSON(): { [key: string]: Record } {
         return this._cache.getState();
     }
 }

--- a/packages/relay-store/src/Store.ts
+++ b/packages/relay-store/src/Store.ts
@@ -151,7 +151,7 @@ export class Store extends RelayModernStore {
     }
 
     private isCurrent(fetchTime: number, ttl: number): boolean {
-        return ttl && fetchTime + ttl >= Date.now();
+        return !!(ttl && fetchTime + ttl >= Date.now());
     }
 
     check(operation: OperationDescriptor, options?: CheckOptions): OperationAvailability {


### PR DESCRIPTION
Addresses https://github.com/morrys/wora/issues/120

## Description

Fixes relay-store types to make the package usable with TSLint and enabled strict mode.

- Fixes `RecordSource` ` toJSON()` return type
- Fixes `Store` `isCurrent()` return type